### PR TITLE
Fixes pip install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,0 @@
-include LICENSE
-include README.rst
-
-recursive-exclude * __pycache__
-recursive-exclude * *.py[co]

--- a/pytest_tank_test/__init__.py
+++ b/pytest_tank_test/__init__.py
@@ -77,15 +77,18 @@ def pytest_configure(config):
             os.path.join(repo_root, "tests", "python"),
         )
 
-    # Exposes the root of all Toolkit reposiroties.
+    # Exposes the root of all Toolkit repositories.
     os.environ["SHOTGUN_REPOS_ROOT"] = repos_root
+
+    # Expose the current repository root.
+    os.environ["SHOTGUN_CURRENT_REPO_ROOT"] = repo_root
 
     # Exposes the location of the test engine bundle.
     os.environ["SHOTGUN_TEST_ENGINE"] = os.path.join(
         os.path.dirname(inspect.getsourcefile(pytest_configure)), "tk-testengine"
     )
 
-    # FIXME: This won't be documented (or renamed) as we're not super comfortable
+    # Note: This won't be documented (or renamed) as we're not super comfortable
     # supporting TankTestBase at the moment for clients to write tests with.
     os.environ["TK_TEST_FIXTURES"] = os.path.join(repo_root, "tests", "fixtures")
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ def read_file(fname):
 
 setup(
     name="tk-toolchain",
-    version="0.1.0",
+    version="0.1.0.dev",
     author="Shotgun Software",
     author_email="support@shotgunsoftware.com",
     maintainer="Shotgun Software",

--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,8 @@ setup(
     description="Build tools for Shotgun Toolkit.",
     long_description=read_file("README.md"),
     packages=find_packages(),
+    data_files=[("", ["LICENSE"])],
     package_data={
-        "": ["README.md", "LICENSE"],
         "tk_toolchain": [
             os.path.join("cmd_line_tools", "tk_docs_preview", "sphinx_data", "*"),
             os.path.join(

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     python_requires=">=2.7.0",
     install_requires=[
         # Tests
-        "pytest>=3.5.0",
+        "pytest==4.6.6",
         "pytest-cov==2.6.1",
         "mock",
         "coverage==4.4.1",

--- a/setup.py
+++ b/setup.py
@@ -34,12 +34,13 @@ setup(
     author_email="support@shotgunsoftware.com",
     maintainer="Shotgun Software",
     maintainer_email="support@shotgunsoftware.com",
-    license="MIT",
+    license=read_file("LICENSE"),
     url="https://github.com/shotgunsoftware/tk-toolchain",
     description="Build tools for Shotgun Toolkit.",
-    long_description=read_file("README.MD"),
+    long_description=read_file("README.md"),
     packages=find_packages(),
     package_data={
+        "": ["README.md", "LICENSE"],
         "tk_toolchain": [
             os.path.join("cmd_line_tools", "tk_docs_preview", "sphinx_data", "*"),
             os.path.join(

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import sys
 import codecs
 from setuptools import setup, find_packages
 
@@ -59,7 +60,9 @@ setup(
         "unittest2",
         # Doc generation
         "PyYAML",
-        "sphinx",
+        # sphinx 2.0 is Python 3 only, so we have to cap out the version
+        # we use on Python 2.
+        "sphinx<=1.8.5" if sys.version_info[0] == 2 else "sphinx",
         "sphinx_rtd_theme",
         # Other tools used by devs that are useful to have.
         "pre-commit",


### PR DESCRIPTION
Module is now properly pip installable from the web. It also caps the version of certain modules that dropped Python 3 support. I would have assumed that pip would have respected the Python version we're using, but apparently it's not or we're doing something wrong.