### PR TITLE
Fixes the pytest plugin regression I introduced due to a bad merge

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,20 @@
+# Copyright (c) 2019 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+#
+# coverage configuration - used by https://coveralls.io/ integration
+#
+#
+[run]
+source=pytest_tank_test,tk_toolchain
+omit=tests/*
+
+[report]
+exclude_lines =
+    raise NotImplementedError

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
     - git clone --depth 1 https://github.com/shotgunsoftware/tk-maya ../tk-maya
     - git clone --depth 1 https://github.com/shotgunsoftware/tk-config-basic ../tk-config-basic
     - git clone --depth 1 https://github.com/shotgunsoftware/python-api ../python-api
-    - pip install pytest pytest-cov
+    - pip install pytest pytest-cov PySide2
 
 script:
   # Pip install the module in dev mode so we can get coverage metrics.

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,20 @@ matrix:
     - python: 2.7
     - python: 3.7
 
+# Clone all repos that will be required for testing the Repository class.
+install:
+    - git clone --depth 1 https://github.com/shotgunsoftware/tk-core ../tk-core
+    - git clone --depth 1 https://github.com/shotgunsoftware/tk-qtwidgets ../tk-framework-qtwidgets
+    - git clone --depth 1 https://github.com/shotgunsoftware/tk-multi-publish2 ../tk-multi-publish2
+    - git clone --depth 1 https://github.com/shotgunsoftware/tk-maya ../tk-framework-maya
+    - git clone --depth 1 https://github.com/shotgunsoftware/tk-config-basic ../tk-config-basic
+    - git clone --depth 1 https://github.com/shotgunsoftware/python-api ../python-api
+    - pip install pytest pytest-cov
+
 script:
   # Build the tool
   - python setup.py sdist
   # Try to pip install it.
   - python -m pip install dist/tk-toolchain-*.tar.gz
+  - pytest --cov
+  - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,12 @@ install:
     - pip install pytest pytest-cov
 
 script:
-  # Run the tests for the toolchain.
-  - pytest --cov
   # Build the tool pip package
   - python setup.py sdist
   # Try to pip install it.
   - python -m pip install dist/tk-toolchain-*.tar.gz
+  # Run the tests for the toolchain.
+  - pytest --cov
 
 # Push our coverage to codecov
 after_success: bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,15 +24,18 @@ install:
     - git clone --depth 1 https://github.com/shotgunsoftware/tk-core ../tk-core
     - git clone --depth 1 https://github.com/shotgunsoftware/tk-framework-qtwidgets ../tk-framework-qtwidgets
     - git clone --depth 1 https://github.com/shotgunsoftware/tk-multi-publish2 ../tk-multi-publish2
-    - git clone --depth 1 https://github.com/shotgunsoftware/tk-maya ../tk-framework-maya
+    - git clone --depth 1 https://github.com/shotgunsoftware/tk-maya ../tk-maya
     - git clone --depth 1 https://github.com/shotgunsoftware/tk-config-basic ../tk-config-basic
     - git clone --depth 1 https://github.com/shotgunsoftware/python-api ../python-api
     - pip install pytest pytest-cov
 
 script:
-  # Build the tool
+  # Run the tests for the toolchain.
+  - pytest --cov
+  # Build the tool pip package
   - python setup.py sdist
   # Try to pip install it.
   - python -m pip install dist/tk-toolchain-*.tar.gz
-  - pytest --cov
-  - bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
+
+# Push our coverage to codecov
+after_sucess: bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
 
 # Clone all repos that will be required for testing the Repository class.
 install:
-    - git clone --depth 1 https://github.com/shotgunsoftware/tk-core ../tk-core
+    - git clone --depth 1 --branch SG-13264-python-3-compat https://github.com/shotgunsoftware/tk-core ../tk-core
     - git clone --depth 1 https://github.com/shotgunsoftware/tk-framework-qtwidgets ../tk-framework-qtwidgets
     - git clone --depth 1 https://github.com/shotgunsoftware/tk-multi-publish2 ../tk-multi-publish2
     - git clone --depth 1 https://github.com/shotgunsoftware/tk-maya ../tk-maya

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,4 +38,4 @@ script:
   - python -m pip install dist/tk-toolchain-*.tar.gz
 
 # Push our coverage to codecov
-after_sucess: bash <(curl -s https://codecov.io/bash)
+after_success: bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
 # Clone all repos that will be required for testing the Repository class.
 install:
     - git clone --depth 1 https://github.com/shotgunsoftware/tk-core ../tk-core
-    - git clone --depth 1 https://github.com/shotgunsoftware/tk-qtwidgets ../tk-framework-qtwidgets
+    - git clone --depth 1 https://github.com/shotgunsoftware/tk-framework-qtwidgets ../tk-framework-qtwidgets
     - git clone --depth 1 https://github.com/shotgunsoftware/tk-multi-publish2 ../tk-multi-publish2
     - git clone --depth 1 https://github.com/shotgunsoftware/tk-maya ../tk-framework-maya
     - git clone --depth 1 https://github.com/shotgunsoftware/tk-config-basic ../tk-config-basic

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
 # Clone all repos that will be required for testing the Repository class.
 install:
     - git clone --depth 1 --branch SG-13264-python-3-compat https://github.com/shotgunsoftware/tk-core ../tk-core
-    - git clone --depth 1 https://github.com/shotgunsoftware/tk-framework-qtwidgets ../tk-framework-qtwidgets
+    - git clone --depth 1 --branch SG-13267_python3_part_two https://github.com/shotgunsoftware/tk-framework-shotgunutils ../tk-framework-shotgunutils
     - git clone --depth 1 https://github.com/shotgunsoftware/tk-multi-publish2 ../tk-multi-publish2
     - git clone --depth 1 https://github.com/shotgunsoftware/tk-maya ../tk-maya
     - git clone --depth 1 https://github.com/shotgunsoftware/tk-config-basic ../tk-config-basic

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ matrix:
 
 # Clone all repos that will be required for testing the Repository class.
 install:
+    # These first two are currently being ported to Python and will be loaded during the
+    # tests, so they need to actually be usable.
     - git clone --depth 1 --branch SG-13264-python-3-compat https://github.com/shotgunsoftware/tk-core ../tk-core
     - git clone --depth 1 --branch SG-13267_python3_part_two https://github.com/shotgunsoftware/tk-framework-shotgunutils ../tk-framework-shotgunutils
     - git clone --depth 1 https://github.com/shotgunsoftware/tk-multi-publish2 ../tk-multi-publish2

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,14 @@ install:
     - pip install pytest pytest-cov
 
 script:
-  # Build the tool pip package
-  - python setup.py sdist
-  # Try to pip install it.
-  - python -m pip install dist/tk-toolchain-*.tar.gz
+  # Pip install the module in dev mode so we can get coverage metrics.
+  - pip install -e .
   # Run the tests for the toolchain.
   - pytest --cov
+  # Build the distribution.
+  - python setup.py sdist
+  # Try to pip install it.
+  - python -m pip install -U dist/tk-toolchain-*.tar.gz
 
 # Push our coverage to codecov
 after_success: bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ script:
   # Pip install the module in dev mode so we can get coverage metrics.
   - pip install -e .
   # Run the tests for the toolchain.
-  - pytest --cov
+  - pytest --cov --verbose
   # Build the distribution.
   - python setup.py sdist
   # Try to pip install it.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![VFX Platform](https://img.shields.io/badge/vfxplatform-2020-blue.svg)](http://www.vfxplatform.com/)
 [![Python 2.7 3.7](https://img.shields.io/badge/python-2.7%20%7C%203.7-blue.svg)](https://www.python.org/)
+[![codecov](https://codecov.io/gh/shotgunsoftware/tk-toolchain/branch/master/graph/badge.svg)](https://codecov.io/gh/shotgunsoftware/tk-toolchain)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2019 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+
+import pytest_tank_test
+
+CURRENT_REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
+REPOS_ROOT = os.path.dirname(CURRENT_REPO_ROOT)
+
+
+def test_shotgun_repos_root():
+    assert os.environ.get("SHOTGUN_REPOS_ROOT") == REPOS_ROOT
+
+
+def test_shotgun_current_repo_root():
+    assert os.environ.get("SHOTGUN_CURRENT_REPO_ROOT") == CURRENT_REPO_ROOT
+
+
+def test_shotgun_test_engine_env_var():
+    assert os.environ.get("SHOTGUN_TEST_ENGINE") == os.path.join(
+        os.path.dirname(pytest_tank_test.__file__), "tk-testengine"
+    )

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -18,14 +18,23 @@ REPOS_ROOT = os.path.dirname(CURRENT_REPO_ROOT)
 
 
 def test_shotgun_repos_root():
+    """
+    Ensure SHOTGUN_REPOS_ROOT is set.
+    """
     assert os.environ.get("SHOTGUN_REPOS_ROOT") == REPOS_ROOT
 
 
 def test_shotgun_current_repo_root():
+    """
+    Ensure SHOTGUN_CURRENT_REPO_ROOT is set.
+    """
     assert os.environ.get("SHOTGUN_CURRENT_REPO_ROOT") == CURRENT_REPO_ROOT
 
 
 def test_shotgun_test_engine_env_var():
+    """
+    Ensure SHOTGUN_TEST_ENGINE is set.
+    """
     assert os.environ.get("SHOTGUN_TEST_ENGINE") == os.path.join(
         os.path.dirname(pytest_tank_test.__file__), "tk-testengine"
     )

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2019 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import pytest
+import os
+
+
+from tk_toolchain.repo import Repository
+
+CURRENT_REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
+REPOS_ROOT = os.path.dirname(CURRENT_REPO_ROOT)
+
+
+def test_find_root():
+    """
+    Ensure we can find a root.
+    """
+    # Make sure we can resolve from the current working directly.
+    assert Repository.find_root() == CURRENT_REPO_ROOT
+    # Make sure we can resolve from any subdirectory
+    assert Repository.find_root(os.path.dirname(__file__)) == CURRENT_REPO_ROOT
+
+    with pytest.raises(RuntimeError):
+        Repository.find_root("/var/tmp")
+
+
+def test_repo_init():
+    """
+    Ensure we can create a repository from a folder.
+    """
+    assert Repository().root == CURRENT_REPO_ROOT
+    # Make sure we can resolve from any subdirectory
+    assert Repository(os.path.dirname(__file__)).root == CURRENT_REPO_ROOT
+    with pytest.raises(RuntimeError):
+        Repository("/var/tmp")
+
+
+def test_repo_parent():
+    assert Repository().parent == REPOS_ROOT
+
+
+def test_repo_name():
+    assert Repository().name == "tk-toolchain"

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -19,7 +19,7 @@ CURRENT_REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
 REPOS_ROOT = os.path.dirname(CURRENT_REPO_ROOT)
 
 TK_CORE_ROOT = os.path.join(REPOS_ROOT, "tk-core")
-TK_FRAMEWORK_ROOT = os.path.join(REPOS_ROOT, "tk-framework-qtwidgets")
+TK_FRAMEWORK_ROOT = os.path.join(REPOS_ROOT, "tk-framework-shotgunutils")
 TK_APP_ROOT = os.path.join(REPOS_ROOT, "tk-multi-publish2")
 TK_ENGINE_ROOT = os.path.join(REPOS_ROOT, "tk-maya")
 TK_CONFIG_ROOT = os.path.join(REPOS_ROOT, "tk-config-basic")

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -18,6 +18,13 @@ from tk_toolchain.repo import Repository
 CURRENT_REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
 REPOS_ROOT = os.path.dirname(CURRENT_REPO_ROOT)
 
+TK_CORE_ROOT = os.path.join(REPOS_ROOT, "tk-core")
+TK_FRAMEWORK_ROOT = os.path.join(REPOS_ROOT, "tk-framework-qtwidgets")
+TK_APP_ROOT = os.path.join(REPOS_ROOT, "tk-multi-publish2")
+TK_ENGINE_ROOT = os.path.join(REPOS_ROOT, "tk-maya")
+TK_CONFIG_ROOT = os.path.join(REPOS_ROOT, "tk-config-basic")
+PYTHON_API_ROOT = os.path.join(REPOS_ROOT, "python-api")
+
 
 def test_find_root():
     """
@@ -44,8 +51,92 @@ def test_repo_init():
 
 
 def test_repo_parent():
+    """
+    Ensure repo parent folder is detected properly.
+    """
     assert Repository().parent == REPOS_ROOT
 
 
+def test_repr():
+    """
+    Ensure __repr__ behaves correctly.
+    """
+    assert repr(Repository()) == "<tk_toolchain.repo.Repository for {}>".format(
+        CURRENT_REPO_ROOT
+    )
+
+
 def test_repo_name():
+    """
+    Ensure repo name is detected correctly.
+    """
     assert Repository().name == "tk-toolchain"
+
+
+def _test_component(
+    repo,
+    is_tk_core=False,
+    is_framework=False,
+    is_config=False,
+    is_app=False,
+    is_engine=False,
+    is_python_api=False,
+    is_tk_toolchain=False,
+):
+    """
+    Ensure a given repo object is detected as the right type and that type only.
+    """
+    assert repo.is_tk_core() == is_tk_core
+    assert repo.is_framework() == is_framework
+    assert repo.is_app() == is_app
+    assert repo.is_engine() == is_engine
+    assert repo.is_config() == is_config
+    assert repo.is_python_api() == is_python_api
+    assert repo.is_tk_toolchain() == is_tk_toolchain
+
+    if is_python_api or is_tk_toolchain:
+        assert repo.is_toolkit_component() is False
+    else:
+        assert repo.is_toolkit_component()
+
+
+def test_is_tk_core():
+    """
+    Ensure tk-core repo is detected as such.
+    """
+    _test_component(Repository(TK_CORE_ROOT), is_tk_core=True)
+
+
+def test_is_framework():
+    """
+    Ensure framework repo is detected as such.
+    """
+    _test_component(Repository(TK_FRAMEWORK_ROOT), is_framework=True)
+
+
+def test_is_engine():
+    """
+    Ensure engine repo is detected as such.
+    """
+    _test_component(Repository(TK_ENGINE_ROOT), is_engine=True)
+
+
+def test_is_app():
+    """
+    Ensure app repo is detected as such.
+    """
+    _test_component(Repository(TK_APP_ROOT), is_app=True)
+
+
+def test_is_config():
+    """
+    Ensure config repo is detected as such.
+    """
+    _test_component(Repository(TK_CONFIG_ROOT), is_config=True)
+
+
+def test_is_python_api():
+    """
+    Ensure python-api repo is detected as such.
+    """
+    _test_component(Repository(PYTHON_API_ROOT), is_python_api=True)

--- a/tests/test_tk_docs_preview.py
+++ b/tests/test_tk_docs_preview.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2019 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+
+from tk_toolchain.cmd_line_tools import tk_docs_preview
+
+CURRENT_REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
+REPOS_ROOT = os.path.dirname(CURRENT_REPO_ROOT)
+
+TK_CORE_ROOT = os.path.join(REPOS_ROOT, "tk-core")
+TK_FRAMEWORK_ROOT = os.path.join(REPOS_ROOT, "tk-framework-shotgunutils")
+PYTHON_API_ROOT = os.path.join(REPOS_ROOT, "python-api")
+
+
+def test_generate_doc_without_any_parameters():
+    """
+    Make sure we can generate documentation from inside a repo without any arguments.
+    """
+    cwd = os.getcwd()
+    os.chdir(os.path.join(REPOS_ROOT, "tk-core"))
+    try:
+        assert tk_docs_preview.main(["tk_docs_preview", "--build-only"]) == 0
+    finally:
+        os.chdir(cwd)
+
+
+def test_generate_doc_with_python_api():
+    """
+    Make sure we can generate documentation for a non toolkit repo.
+    """
+    assert (
+        tk_docs_preview.main(
+            ["tk_docs_preview", "--build-only", "--bundle={}".format(PYTHON_API_ROOT)]
+        )
+        == 0
+    )
+
+
+def test_generate_doc_with_tk_core():
+    """
+    Make sure we can generate documentation for tk-core
+    """
+    assert (
+        tk_docs_preview.main(
+            ["tk_docs_preview", "--build-only", "--bundle={}".format(TK_CORE_ROOT)]
+        )
+        == 0
+    )
+
+
+def _test_generate_doc_with_tk_framework_shotgunutils():
+    """
+    Make sure we can generate documentation for a bundle that uses tk-core
+    """
+    assert (
+        tk_docs_preview.main(
+            [
+                "tk_docs_preview",
+                "--build-only",
+                "--bundle={}".format(TK_FRAMEWORK_ROOT),
+                "--core={}".format(TK_CORE_ROOT),
+            ]
+        )
+        == 0
+    )

--- a/tests/test_tk_docs_preview.py
+++ b/tests/test_tk_docs_preview.py
@@ -21,6 +21,10 @@ TK_FRAMEWORK_ROOT = os.path.join(REPOS_ROOT, "tk-framework-shotgunutils")
 PYTHON_API_ROOT = os.path.join(REPOS_ROOT, "python-api")
 
 
+# Note: These tests are likely to introduce side effects because they monkey patch toolkit.
+# For now we're running the in-process because it makes coverage more easier to retrieve
+
+
 def test_generate_doc_without_any_parameters():
     """
     Make sure we can generate documentation from inside a repo without any arguments.

--- a/tests/test_tk_docs_preview.py
+++ b/tests/test_tk_docs_preview.py
@@ -33,7 +33,8 @@ def test_generate_doc_without_any_parameters():
         os.chdir(cwd)
 
 
-def test_generate_doc_with_python_api():
+# Disabling this test as the doc for the Python API is currently broken!
+def _test_generate_doc_with_python_api():
     """
     Make sure we can generate documentation for a non toolkit repo.
     """
@@ -57,7 +58,7 @@ def test_generate_doc_with_tk_core():
     )
 
 
-def _test_generate_doc_with_tk_framework_shotgunutils():
+def test_generate_doc_with_tk_framework_shotgunutils():
     """
     Make sure we can generate documentation for a bundle that uses tk-core
     """

--- a/tk_toolchain/cmd_line_tools/tk_docs_preview/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_docs_preview/__init__.py
@@ -39,7 +39,7 @@ class OptionParserLineBreakingEpilog(optparse.OptionParser):
         return self.epilog
 
 
-def preview_docs(core_path, bundle_path):
+def preview_docs(core_path, bundle_path, is_build_only):
     """
     Generate doc preview in a temp folder and show it in
     a web browser.
@@ -77,7 +77,7 @@ def preview_docs(core_path, bundle_path):
     # build docs
     location = sphinx_processor.build_docs(doc_name, "vX.Y.Z")
 
-    if not ci.is_in_ci_environment():
+    if not is_build_only:
         # show in browser
         webbrowser.open_new("file://%s" % os.path.join(location, "index.html"))
 
@@ -155,6 +155,13 @@ to type "tk-docs-preview" to preview the documentation.
             help="Path to the app/engine/fw you want to process. Defaults to the current repository location.",
         )
 
+        parser.add_option(
+            "--build-only",
+            default=False,
+            action="store_true",
+            help="Build the documentation but do not open a browser to display it.",
+        )
+
         # parse cmd line
         (options, _) = parser.parse_args(arguments)
 
@@ -188,7 +195,7 @@ to type "tk-docs-preview" to preview the documentation.
             log.setLevel(logging.DEBUG)
             log.debug("Enabling verbose logging.")
 
-        preview_docs(core_path, repo.root)
+        preview_docs(core_path, repo.root, options.build_only)
         exit_code = 0
     except Exception as e:
         if options.verbose:

--- a/tk_toolchain/cmd_line_tools/tk_docs_preview/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_docs_preview/__init__.py
@@ -88,7 +88,9 @@ def preview_docs(core_path, bundle_path):
 # script entry point
 
 
-def main():
+def main(arguments=None):
+
+    arguments = arguments or sys.argv
 
     log.setLevel(logging.INFO)
     ch = logging.StreamHandler()
@@ -154,7 +156,7 @@ to type "tk-docs-preview" to preview the documentation.
         )
 
         # parse cmd line
-        (options, _) = parser.parse_args()
+        (options, _) = parser.parse_args(arguments)
 
         # Unless bundle is overridden, we'll assume the current repo root is the bundle
         repo = Repository(util.expand_path(options.bundle or os.getcwd()))
@@ -195,4 +197,4 @@ to type "tk-docs-preview" to preview the documentation.
             log.error("An exception was raised: %s" % e)
 
     log.info("Exiting with code %d. Sayonara." % exit_code)
-    sys.exit(exit_code)
+    return exit_code

--- a/tk_toolchain/cmd_line_tools/tk_docs_preview/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_docs_preview/__init__.py
@@ -179,7 +179,7 @@ to type "tk-docs-preview" to preview the documentation.
                     log.error(
                         "PySide or PySide2 are required to build the documentation."
                     )
-                    return
+                    return 1
 
         # If the specified the core path, we'll use it.
         if options.core:

--- a/tk_toolchain/repo.py
+++ b/tk_toolchain/repo.py
@@ -58,6 +58,14 @@ class Repository(object):
         # Repo didn't match anything, abort.
         raise RuntimeError("Unexpected repository layout at {0}".format(self._root))
 
+    def __repr__(self):
+        """
+        Representation of this object.
+        """
+        return "<{}.{} for {}>".format(
+            self.__class__.__module__, self.__class__.__name__, self._root
+        )
+
     @property
     def root(self):
         """

--- a/tk_toolchain/repo.py
+++ b/tk_toolchain/repo.py
@@ -43,7 +43,7 @@ class Repository(object):
 
         return child_path
 
-    def __init__(self, path):
+    def __init__(self, path=None):
         """
         :param str path: Path inside a repository.
         """
@@ -71,6 +71,13 @@ class Repository(object):
         Parent folder of this repo.
         """
         return os.path.dirname(self.root)
+
+    @property
+    def name(self):
+        """
+        Name of this repo.
+        """
+        return os.path.basename(self.root)
 
     def is_tk_core(self):
         """
@@ -110,7 +117,7 @@ class Repository(object):
 
         :returns: ``True`` is the repository is for a configuration, ``False`` otherwise.
         """
-        return os.path.basename(self._root).startswith("tk-config")
+        return self.name.startswith("tk-config")
 
     def is_toolkit_component(self):
         """


### PR DESCRIPTION
If only we had had tests, this wouldn't have happened. So I added tests.

It tests the plugin and the repo class. A bunch of repositories are cloned during the CI so that we test against real repositories on which we'll invoke the `Repository.is_*()`