### PR TITLE
Test engine now initializes Qt automatically

### DIFF
--- a/pytest_tank_test/__init__.py
+++ b/pytest_tank_test/__init__.py
@@ -33,7 +33,6 @@ def _initialize_logging():
 
     tank.LogManager().initialize_base_file_handler("tk-test")
     tank.LogManager().initialize_custom_handler()
-    tank.LogManager().global_debug = True
 
 
 def pytest_configure(config):

--- a/pytest_tank_test/tk-testengine/engine.py
+++ b/pytest_tank_test/tk-testengine/engine.py
@@ -22,6 +22,13 @@ class TestEngine(sgtk.platform.Engine):
     """
 
     def pre_app_init(self):
+        """
+        Called before apps and loaded.
+        """
+        # Since this method is called after Qt has been setup, but before
+        # apps have been loaded, this makes it the perfect opportunity to
+        # initialize QApplication so that apps can call has_ui and get a
+        # positive answer back from the engine.
         try:
             q_app = sgtk.platform.qt.QtGui.QApplication.instance()
             self._q_app = q_app or sgtk.platform.qt.QtGui.QApplication([])

--- a/pytest_tank_test/tk-testengine/engine.py
+++ b/pytest_tank_test/tk-testengine/engine.py
@@ -9,9 +9,30 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from sgtk.platform import Engine
+import sgtk
 
 
-class TestEngine(Engine):
+class TestEngine(sgtk.platform.Engine):
+    """
+    Test engine.
+
+    The engine will initialize a QApplication if possible right before
+    applications start registering themselves so it looks as if they
+    are running within a GUI environment.
+    """
+
+    def pre_app_init(self):
+        try:
+            app = sgtk.platform.qt.QtGui.QApplication.instance()
+            app = app or sgtk.platform.qt.QtGui.QApplication([])
+        except Exception:
+            app = None
+
+        if app:
+            self._initialize_dark_look_and_feel()
+
     def _emit_log_message(self, handler, record):
+        """
+        Print any log message to the console.
+        """
         print(handler.format(record))

--- a/pytest_tank_test/tk-testengine/engine.py
+++ b/pytest_tank_test/tk-testengine/engine.py
@@ -24,12 +24,20 @@ class TestEngine(sgtk.platform.Engine):
     def pre_app_init(self):
         try:
             app = sgtk.platform.qt.QtGui.QApplication.instance()
-            app = app or sgtk.platform.qt.QtGui.QApplication([])
+            self._app = app or sgtk.platform.qt.QtGui.QApplication([])
         except Exception:
-            app = None
+            # This will fail if Qt is not available.
+            self._app = None
 
-        if app:
+        if self._app:
             self._initialize_dark_look_and_feel()
+
+    @property
+    def app(self):
+        """
+        The QtGui.QApplication instance, if available.
+        """
+        return self._app
 
     def _emit_log_message(self, handler, record):
         """

--- a/pytest_tank_test/tk-testengine/engine.py
+++ b/pytest_tank_test/tk-testengine/engine.py
@@ -23,21 +23,21 @@ class TestEngine(sgtk.platform.Engine):
 
     def pre_app_init(self):
         try:
-            app = sgtk.platform.qt.QtGui.QApplication.instance()
-            self._app = app or sgtk.platform.qt.QtGui.QApplication([])
+            q_app = sgtk.platform.qt.QtGui.QApplication.instance()
+            self._q_app = q_app or sgtk.platform.qt.QtGui.QApplication([])
         except Exception:
             # This will fail if Qt is not available.
-            self._app = None
+            self._q_app = None
 
-        if self._app:
+        if self._q_app:
             self._initialize_dark_look_and_feel()
 
     @property
-    def app(self):
+    def q_app(self):
         """
         The QtGui.QApplication instance, if available.
         """
-        return self._app
+        return self._q_app
 
     def _emit_log_message(self, handler, record):
         """


### PR DESCRIPTION
Really, this should have been done right away, as it makes all the tests so much simpler to write when you can just assume Qt is ready to use.

I've also removed debug logging being forced for every tests. It prints way too much text when something is failing on pytest. We'll still force it on manually in CI, since we want as much data as possible to debug a build that ran, but locally often the warning and errors messages are good enough.