### PR TITLE
Skip pytest plugin initialization on non-toolkit repos

### DIFF
--- a/pytest_tank_test/__init__.py
+++ b/pytest_tank_test/__init__.py
@@ -58,7 +58,11 @@ def pytest_configure(config):
         valid_repo = False
     else:
         # Make sure we're in a toolkit component
-        valid_repo = repo.is_toolkit_component()
+        valid_repo = (
+            repo.is_toolkit_component()
+            or repo.is_python_api()
+            or repo.is_tk_toolchain()
+        )
     # If we were unable to construct a Repository object, or if we're not in a
     # toolkit component repo, bail.
     if valid_repo is False:

--- a/pytest_tank_test/__init__.py
+++ b/pytest_tank_test/__init__.py
@@ -60,7 +60,7 @@ def pytest_configure(config):
         # Make sure we're in a toolkit component
         valid_repo = repo.is_shotgun_component()
     # If we were unable to construct a Repository object, or if we're not in a
-    # toolkit component repo, bail.
+    # shotgun component repo, bail.
     if valid_repo is False:
         print(
             "%s does not appear to be inside Shotgun repository. Skipping initialization of 'pytest_tank_test.'"

--- a/pytest_tank_test/__init__.py
+++ b/pytest_tank_test/__init__.py
@@ -52,9 +52,17 @@ def pytest_configure(config):
     cur_dir = os.path.abspath(os.curdir)
 
     # The path to the current repo root
+    valid_repo = True
     try:
         repo = Repository(cur_dir)
     except RuntimeError:
+        valid_repo = False
+    else:
+        if repo.is_toolkit_component() is False:
+            valid_repo = False
+    # If we were unable to construct a Repository object, or if we're not in a
+    # toolkit component repo, bail.
+    if valid_repo is False:
         print(
             "This does not appear to be a Toolkit repository. Skipping initialization of 'pytest_tank_test.'"
         )

--- a/pytest_tank_test/__init__.py
+++ b/pytest_tank_test/__init__.py
@@ -52,14 +52,13 @@ def pytest_configure(config):
     cur_dir = os.path.abspath(os.curdir)
 
     # The path to the current repo root
-    valid_repo = True
     try:
         repo = Repository(cur_dir)
     except RuntimeError:
         valid_repo = False
     else:
-        if repo.is_toolkit_component() is False:
-            valid_repo = False
+        # Make sure we're in a toolkit component
+        valid_repo = repo.is_toolkit_component()
     # If we were unable to construct a Repository object, or if we're not in a
     # toolkit component repo, bail.
     if valid_repo is False:

--- a/pytest_tank_test/__init__.py
+++ b/pytest_tank_test/__init__.py
@@ -58,16 +58,13 @@ def pytest_configure(config):
         valid_repo = False
     else:
         # Make sure we're in a toolkit component
-        valid_repo = (
-            repo.is_toolkit_component()
-            or repo.is_python_api()
-            or repo.is_tk_toolchain()
-        )
+        valid_repo = repo.is_shotgun_component()
     # If we were unable to construct a Repository object, or if we're not in a
     # toolkit component repo, bail.
     if valid_repo is False:
         print(
-            "This does not appear to be a Toolkit repository. Skipping initialization of 'pytest_tank_test.'"
+            "%s does not appear to be inside Shotgun repository. Skipping initialization of 'pytest_tank_test.'"
+            % cur_dir
         )
         return
 

--- a/tests/test_repo.py
+++ b/tests/test_repo.py
@@ -94,6 +94,10 @@ def _test_component(
     assert repo.is_config() == is_config
     assert repo.is_python_api() == is_python_api
     assert repo.is_tk_toolchain() == is_tk_toolchain
+    assert repo.is_shotgun_component()
+    assert repo.is_toolkit_component() == (
+        is_tk_core or is_framework or is_engine or is_config or is_app
+    )
 
     if is_python_api or is_tk_toolchain:
         assert repo.is_toolkit_component() is False

--- a/tk_toolchain/repo.py
+++ b/tk_toolchain/repo.py
@@ -26,6 +26,8 @@ class Repository(object):
         :param str path: One of the descendant folders.
 
         :returns: Path to the repository root.
+
+        :raises RuntimeError: If the path is not inside a repository
         """
 
         child_path = path or os.getcwd()
@@ -46,15 +48,10 @@ class Repository(object):
     def __init__(self, path=None):
         """
         :param str path: Path inside a repository.
+
+        :raises RuntimeError: If the path is not inside a repository
         """
         self._root = self.find_root(path)
-        # Ensure the root is pointing to a valid repository type.
-        if (
-            self.is_tk_toolchain()
-            or self.is_python_api()
-            or self.is_toolkit_component()
-        ):
-            return
 
     def __repr__(self):
         """
@@ -149,6 +146,20 @@ class Repository(object):
             or self.is_app()
             or self.is_config()
             or self.is_tk_core()
+        )
+
+    def is_shotgun_component(self):
+        """
+        Check if the repository is for a Shotgun component
+
+        This can be a Toolkit component, tk-toolchain or the Python API.
+
+        :returns: ``True`` is the repository is for Shotgun component, ``False`` otherwise.
+        """
+        return (
+            self.is_toolkit_component()
+            or self.is_tk_toolchain()
+            or self.is_python_api()
         )
 
     def is_tk_toolchain(self):

--- a/tk_toolchain/repo.py
+++ b/tk_toolchain/repo.py
@@ -150,7 +150,7 @@ class Repository(object):
 
     def is_shotgun_component(self):
         """
-        Check if the repository is for a Shotgun component
+        Check if the repository is for a Shotgun component.
 
         This can be a Toolkit component, tk-toolchain or the Python API.
 


### PR DESCRIPTION
While there's already check for non-repo, the Repository object successfully initializes on non-toolkit repos (with no guarantee of tk-core being available.)

Add a test to see if `Repository.is_toolkit_component()` is True and an early exit to prevent the plugin init from raising an Exception like the one below in this case.

```REMC02XG31CJG5J:python cavanaw$ pytest -s
Repository found at /Users/cavanaw/adam/adam
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/Users/cavanaw/Library/Python/2.7/lib/python/site-packages/_pytest/main.py", line 202, in wrap_session
INTERNALERROR>     config._do_configure()
INTERNALERROR>   File "/Users/cavanaw/Library/Python/2.7/lib/python/site-packages/_pytest/config/__init__.py", line 671, in _do_configure
INTERNALERROR>     self.hook.pytest_configure.call_historic(kwargs=dict(config=self))
INTERNALERROR>   File "/Users/cavanaw/Library/Python/2.7/lib/python/site-packages/pluggy/hooks.py", line 308, in call_historic
INTERNALERROR>     res = self._hookexec(self, self.get_hookimpls(), kwargs)
INTERNALERROR>   File "/Users/cavanaw/Library/Python/2.7/lib/python/site-packages/pluggy/manager.py", line 93, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
INTERNALERROR>   File "/Users/cavanaw/Library/Python/2.7/lib/python/site-packages/pluggy/manager.py", line 87, in <lambda>
INTERNALERROR>     firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
INTERNALERROR>   File "/Users/cavanaw/Library/Python/2.7/lib/python/site-packages/pluggy/callers.py", line 208, in _multicall
INTERNALERROR>     return outcome.get_result()
INTERNALERROR>   File "/Users/cavanaw/Library/Python/2.7/lib/python/site-packages/pluggy/callers.py", line 81, in get_result
INTERNALERROR>     _reraise(*ex)  # noqa
INTERNALERROR>   File "/Users/cavanaw/Library/Python/2.7/lib/python/site-packages/pluggy/callers.py", line 187, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/Users/cavanaw/git/tk-toolchain/pytest_tank_test/__init__.py", line 83, in pytest_configure
INTERNALERROR>     _initialize_logging()
INTERNALERROR>   File "/Users/cavanaw/git/tk-toolchain/pytest_tank_test/__init__.py", line 35, in _initialize_logging
INTERNALERROR>     import tank
INTERNALERROR> ImportError: No module named tank```