### PR TITLE
prints out the Python version, that tk-run-app is running in.

### DIFF
--- a/tk_toolchain/cmd_line_tools/tk_run_app/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_run_app/__init__.py
@@ -159,6 +159,8 @@ def _start_engine(repo, entity_type, entity_id):
             )
         )
 
+    print("Python Version: {0}".format(sys.version))
+
     print("Launching test engine in context {0}".format(context))
 
     # Find the first non-template project and use it.


### PR DESCRIPTION
When running `tk-run-app` command, it will now print out the Python version at the start:

```
Python Version: 2.7.16 (default, Jan 31 2020, 15:30:16)
```

I find I'm not always sure what the environment my shell is in, and so having the print helps confirm exactly what the app is running in.