### PR TITLE
Pinning ordereddict 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,6 +39,9 @@ variables:
 
 jobs:
 - template: build-pipeline.yml@templates
+  # Tell the build system that we want to pip install tk-toolchain
+  # from the current branch.
+  tk_toolchain_ref: $(Build.SourceBranch)
   parameters:
     additional_repositories:
     - name: tk-framework-shotgunutils
@@ -47,14 +50,3 @@ jobs:
     - name: tk-config-basic
       ref: v1.3.0
     - name: python-api
-
-    extra_test_dependencies:
-      # Replaces tk-toolchain with this branch's copy
-      - "--editable ."
-
-    # After the tests have run, run the integration tests.
-    post_tests_steps:
-      - bash: |
-          python setup.py sdist
-          python -m pip install -U dist/tk-toolchain-*.tar.gz
-        displayName: Validate setup.py

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,10 +39,11 @@ variables:
 
 jobs:
 - template: build-pipeline.yml@templates
-  # Tell the build system that we want to pip install tk-toolchain
-  # from the current branch.
-  tk_toolchain_ref: $(Build.SourceBranch)
   parameters:
+    # Tell the build system that we want to pip install tk-toolchain
+    # from the current branch.
+    tk_toolchain_ref: $(Build.SourceBranch)
+    # These extra repositories are required to test some of the command line tools
     additional_repositories:
     - name: tk-framework-shotgunutils
     - name: tk-multi-publish2

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
     ]
     # Other tools used by devs that are useful to have.
     + (["pre-commit", "ruamel.yaml"] if is_python_27_or_greater else [])
-    + (["ruamel.orderedict==0.4.14;sys_platform=='win32'"] if is_python_27 else []),
+    + (["ruamel.ordereddict==0.4.14;sys_platform=='win32'"] if is_python_27 else []),
     classifiers=[
         "Development Status :: 4 - Beta",
         "Framework :: Pytest",

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,8 @@ setup(
         "six==1.14.0",
     ]
     # Other tools used by devs that are useful to have.
-    + (["pre-commit", "ruamel.yaml"] if is_python_27_or_greater else []),
+    + (["pre-commit", "ruamel.yaml"] if is_python_27_or_greater else [])
+    + (["ruamel.orderedict==0.4.14;sys_platform=='win32'"] if is_python_27 else []),
     classifiers=[
         "Development Status :: 4 - Beta",
         "Framework :: Pytest",


### PR DESCRIPTION
The developer of ruamel.ordereddict is not updating 2.7 anymore, or at the very least is not [concerned by updating 2.7 wheels](https://sourceforge.net/p/ruamel-ordereddict/tickets/13/#aa47), so we're locking down the version.

I lost a solid hour trying to understand why Azure Pipelines would keep trying to install 0.4.15 when setup.py said 0.4.14. That's because tk-ci-tools always installs tk-toolchain from master first. Then later in the build we force install the local copy. Instead of doing a lot of work in tk-ci-tools to prevent it from installing from master, I'm actually telling it to install tk-toolchain from my repo's current branch!
