### PR TITLE
Adds tk-framework-widget 1.x.x to the config

### DIFF
--- a/tk_toolchain/cmd_line_tools/tk_run_app/config/env/test.yml
+++ b/tk_toolchain/cmd_line_tools/tk_run_app/config/env/test.yml
@@ -44,3 +44,7 @@ frameworks:
     location:
       type: path
       path: $SHOTGUN_REPOS_ROOT/tk-framework-widget
+  tk-framework-widget_v1.x.x:
+    location:
+      type: path
+      path: $SHOTGUN_REPOS_ROOT/tk-framework-widget


### PR DESCRIPTION
A new major version of the framework has been introduced, so we need to be able to support it with `tk-run-app`.