### PR TITLE
Adding a new method to create a unique project name.

### DIFF
--- a/tests/test_unique_name.py
+++ b/tests/test_unique_name.py
@@ -18,8 +18,8 @@ def test_with_env_var(monkeypatch):
     Using monkeypatch to avoid modifying the environment that can affect other tests.
     """
     monkeypatch.setenv("SHOTGUN_TEST_ENTITY_SUFFIX", "Potatoe")
-    project_name = create_unique_name("Test-")
-    assert project_name == "Test-Potatoe"
+    project_name = create_unique_name("Test")
+    assert project_name == "Test - Potatoe"
 
 
 def test_without_env_var(monkeypatch):

--- a/tests/test_unique_name.py
+++ b/tests/test_unique_name.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+from tk_toolchain.testing import create_unique_name
+
+
+def test_with_env_var():
+    """
+    Ensure the env var is added to the name
+    """
+    os.environ["SHOTGUN_TEST_ENTITY_SUFFIX"] = "Potatoe"
+    project_name = create_unique_name("Test-")
+    assert project_name == "Test-Potatoe"
+
+
+def test_without_env_var():
+    """
+    Ensure we are only getting the name
+    """
+    if "SHOTGUN_TEST_ENTITY_SUFFIX" in os.environ:
+        del os.environ["SHOTGUN_TEST_ENTITY_SUFFIX"]
+    project_name = create_unique_name("Test")
+    assert project_name == "Test"

--- a/tests/test_unique_name.py
+++ b/tests/test_unique_name.py
@@ -9,24 +9,23 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-import os
 from tk_toolchain.testing import create_unique_name
 
 
-def test_with_env_var():
+def test_with_env_var(monkeypatch):
     """
-    Ensure the env var is added to the name
+    Ensure the env var is added to the name.
+    Using monkeypatch to avoid modifying the environment that can affect other tests.
     """
-    os.environ["SHOTGUN_TEST_ENTITY_SUFFIX"] = "Potatoe"
+    monkeypatch.setenv("SHOTGUN_TEST_ENTITY_SUFFIX", "Potatoe")
     project_name = create_unique_name("Test-")
     assert project_name == "Test-Potatoe"
 
 
-def test_without_env_var():
+def test_without_env_var(monkeypatch):
     """
     Ensure we are only getting the name
     """
-    if "SHOTGUN_TEST_ENTITY_SUFFIX" in os.environ:
-        del os.environ["SHOTGUN_TEST_ENTITY_SUFFIX"]
+    monkeypatch.delenv("SHOTGUN_TEST_ENTITY_SUFFIX", raising=False)
     project_name = create_unique_name("Test")
     assert project_name == "Test"

--- a/tk_toolchain/testing.py
+++ b/tk_toolchain/testing.py
@@ -28,7 +28,7 @@ def create_unique_name(name):
     :returns: The name with a suffix is one was specified by the environment variable.
     """
     if "SHOTGUN_TEST_ENTITY_SUFFIX" in os.environ:
-        project_name = name + os.environ["SHOTGUN_TEST_ENTITY_SUFFIX"]
+        project_name = name + " - " + os.environ["SHOTGUN_TEST_ENTITY_SUFFIX"]
     else:
         project_name = name
 

--- a/tk_toolchain/testing.py
+++ b/tk_toolchain/testing.py
@@ -17,7 +17,7 @@ def create_unique_name(name):
     Create a project unique name by passing environment.
     """
     if "SHOTGUN_TEST_ENTITY_SUFFIX" in os.environ:
-        project_name = (name + os.environ["SHOTGUN_TEST_ENTITY_SUFFIX"])
+        project_name = name + os.environ["SHOTGUN_TEST_ENTITY_SUFFIX"]
     else:
         project_name = name
 

--- a/tk_toolchain/testing.py
+++ b/tk_toolchain/testing.py
@@ -14,7 +14,18 @@ import os
 
 def create_unique_name(name):
     """
-    Create a project unique name by passing environment.
+    Create a unique name.
+
+    When ``SHOTGUN_TEST_ENTITY_SUFFIX`` is set, the suffix is added to the name. This can be useful
+    in a CI environment where multiple resources can be created on a server and each need a unique
+    name.
+
+    It is the responsibility of the CI environment to set ``SHOTGUN_TEST_ENTITY_SUFFIX`` for this method
+    to work. If the environment variable is not set, the name is returned as is.
+
+    :param str name: Name that needs to be made unique.
+
+    :returns: The name with a suffix is one was specified by the environment variable.
     """
     if "SHOTGUN_TEST_ENTITY_SUFFIX" in os.environ:
         project_name = name + os.environ["SHOTGUN_TEST_ENTITY_SUFFIX"]

--- a/tk_toolchain/testing.py
+++ b/tk_toolchain/testing.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+
+
+def create_unique_name(name):
+    """
+    Create a project unique name by passing environment.
+    """
+    if "SHOTGUN_TEST_ENTITY_SUFFIX" in os.environ:
+        project_name = (name + os.environ["SHOTGUN_TEST_ENTITY_SUFFIX"])
+    else:
+        project_name = name
+
+    return project_name


### PR DESCRIPTION
Adding a new method to create a unique project name if the env var SHOTGUN_TEST_ENTITY_SUFFIX is set. It takes a single parameter, the project name and then adds the content of the env var.