### PR TITLE
Pin jinja2 version to 3.0.3 to avoid breaking the build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,8 @@ setup(
         "six==1.14.0",
         # Lock down docutils because 0.18 break the build.
         "docutils==0.17.1",
+        # Lock down jinja because 3.1.0 breaks the build.
+        "jinja2==3.0.3",
     ]
     # Other tools used by devs that are useful to have.
     + (["pre-commit", "ruamel.yaml"] if is_python_27_or_greater else [])


### PR DESCRIPTION
jinja2 version 3.1.0 was released on Match 24th and came with some changes that breaks the build.

We needed to pin this package to version 3.0.3 to ensure that everything related with documentation will pass.

This was the error in Azure Pipeline:

```
INFO [CMD: /opt/hostedtoolcache/Python/3.7.12/x64/bin/python -m sphinx -c "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_data" -W -T -E -D project="s" -D release="vX.Y.Z" -D version="vX.Y.Z" "/home/vsts/work/1/s/docs" "/tmp/sphinx-build/s"]
Running Sphinx v1.8.5

Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/sphinx/registry.py", line 472, in load_extension
    mod = __import__(extname, None, None, ['setup'])
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/shiboken2/files.dir/shibokensupport/__feature__.py", line 142, in _import
    return original_import(name, *args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/sphinx/builders/latex/__init__.py", line 37, in <module>
    from sphinx.writers.latex import DEFAULT_SETTINGS, LaTeXWriter, LaTeXTranslator
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/shiboken2/files.dir/shibokensupport/__feature__.py", line 142, in _import
    return original_import(name, *args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/sphinx/writers/latex.py", line 33, in <module>
    from sphinx.util.template import LaTeXRenderer
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/shiboken2/files.dir/shibokensupport/__feature__.py", line 142, in _import
    return original_import(name, *args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/sphinx/util/template.py", line 17, in <module>
    from sphinx.jinja2glue import SphinxFileSystemLoader
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/shiboken2/files.dir/shibokensupport/__feature__.py", line 142, in _import
    return original_import(name, *args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/sphinx/jinja2glue.py", line 16, in <module>
    from jinja2 import FileSystemLoader, BaseLoader, TemplateNotFound, \
ImportError: cannot import name 'contextfunction' from 'jinja2' (/opt/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/site-packages/jinja2/__init__.py)

```