### PR TITLE
SHOT-3998: Update tk-docs-preview cmd line tool

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
       args: [--select=F]
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/ambv/black
-    rev: 21.9b0
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3

--- a/tk_toolchain/cmd_line_tools/tk_docs_generation/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_docs_generation/__init__.py
@@ -83,7 +83,7 @@ def preview_docs(
 
     additional_static_paths = []
     bundle_static_path = os.path.join(bundle_path, "docs", "_static")
-    if bundle_static_path:
+    if os.path.exists(bundle_static_path):
         additional_static_paths.append(bundle_static_path)
 
     # build docs

--- a/tk_toolchain/cmd_line_tools/tk_docs_generation/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_docs_generation/__init__.py
@@ -218,6 +218,11 @@ to type "tk-docs-preview" to preview the documentation.
             log.setLevel(logging.DEBUG)
             log.debug("Enabling verbose logging.")
 
+        if options.additional_paths:
+            additional_paths = options.additional_paths.split(";")
+        else:
+            additional_paths = None
+
         # FIXME: Warnings as error is turned off for the Python API, because that API currently has errors in it.
         # It's too late to fix (we're rebranding), so we'll just disable warnings_as_error for now.
         preview_docs(
@@ -225,7 +230,7 @@ to type "tk-docs-preview" to preview the documentation.
             repo.root,
             options.build_only,
             warnings_as_errors=not repo.is_python_api(),
-            additional_paths=options.additional_paths.split(";"),
+            additional_paths=additional_paths,
         )
         exit_code = 0
     except Exception as e:

--- a/tk_toolchain/cmd_line_tools/tk_docs_generation/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_docs_generation/__init__.py
@@ -38,17 +38,19 @@ class OptionParserLineBreakingEpilog(optparse.OptionParser):
         return self.epilog
 
 
-def preview_docs(core_path, bundle_path, is_build_only, warnings_as_errors=True):
+def preview_docs(core_path, bundle_path, is_build_only, warnings_as_errors=True, additional_paths=None):
     """
     Generate doc preview in a temp folder and show it in
     a web browser.
 
     :param core_path: Path to toolkit core
     :param bundle_path: Path to app/engine/fw to document
+    :param additional_paths: Additional file paths to prepend to the PYTHONPATH and sys.path, for
+        sphinx to generate the docs.
     """
 
     log.info("Starting preview run for %s" % bundle_path)
-    sphinx_processor = SphinxProcessor(core_path, bundle_path, log)
+    sphinx_processor = SphinxProcessor(core_path, bundle_path, log, additional_paths)
 
     # Project Name:
     # assume the name of the folder is the name of the sphinx project
@@ -161,6 +163,15 @@ to type "tk-docs-preview" to preview the documentation.
             help="Build the documentation but do not open a browser to display it.",
         )
 
+        parser.add_option(
+            "--additional-paths",
+            default=None,
+            help=(
+                "Additional file paths to prepend to the PYTHONPATH and sys.path before Sphinx generates "
+                "the docs. Specify multiple file paths by separating with semi-colon ';'."
+            ),
+        )
+
         # parse cmd line
         (options, _) = parser.parse_args(arguments)
 
@@ -209,6 +220,7 @@ to type "tk-docs-preview" to preview the documentation.
             repo.root,
             options.build_only,
             warnings_as_errors=not repo.is_python_api(),
+            additional_paths=options.additional_paths.split(";"),
         )
         exit_code = 0
     except Exception as e:

--- a/tk_toolchain/cmd_line_tools/tk_docs_generation/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_docs_generation/__init__.py
@@ -38,7 +38,13 @@ class OptionParserLineBreakingEpilog(optparse.OptionParser):
         return self.epilog
 
 
-def preview_docs(core_path, bundle_path, is_build_only, warnings_as_errors=True, additional_paths=None):
+def preview_docs(
+    core_path,
+    bundle_path,
+    is_build_only,
+    warnings_as_errors=True,
+    additional_paths=None,
+):
     """
     Generate doc preview in a temp folder and show it in
     a web browser.
@@ -81,7 +87,9 @@ def preview_docs(core_path, bundle_path, is_build_only, warnings_as_errors=True,
         additional_static_paths.append(bundle_static_path)
 
     # build docs
-    location = sphinx_processor.build_docs(doc_name, "vX.Y.Z", warnings_as_errors, additional_static_paths)
+    location = sphinx_processor.build_docs(
+        doc_name, "vX.Y.Z", warnings_as_errors, additional_static_paths
+    )
 
     if not is_build_only:
         # show in browser
@@ -218,6 +226,7 @@ to type "tk-docs-preview" to preview the documentation.
             log.setLevel(logging.DEBUG)
             log.debug("Enabling verbose logging.")
 
+        # Get the additional paths from the command line options. Split the string by ';' for multiple paths.
         if options.additional_paths:
             additional_paths = options.additional_paths.split(";")
         else:

--- a/tk_toolchain/cmd_line_tools/tk_docs_generation/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_docs_generation/__init__.py
@@ -75,8 +75,13 @@ def preview_docs(core_path, bundle_path, is_build_only, warnings_as_errors=True,
         "the release script, the proper github details will be extracted."
     )
 
+    additional_static_paths = []
+    bundle_static_path = os.path.join(bundle_path, "docs", "_static")
+    if bundle_static_path:
+        additional_static_paths.append(bundle_static_path)
+
     # build docs
-    location = sphinx_processor.build_docs(doc_name, "vX.Y.Z", warnings_as_errors)
+    location = sphinx_processor.build_docs(doc_name, "vX.Y.Z", warnings_as_errors, additional_static_paths)
 
     if not is_build_only:
         # show in browser

--- a/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_data/conf.py
+++ b/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_data/conf.py
@@ -195,8 +195,8 @@ master_doc = "index"
 # project = u'Specify this via command line'
 from datetime import date
 
-copyright = u"%s, Autodesk" % date.today().year
-author = u"Autodesk"
+copyright = "%s, Autodesk" % date.today().year
+author = "Autodesk"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_processor.py
+++ b/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_processor.py
@@ -34,12 +34,13 @@ class SphinxProcessor(object):
     Class that wraps sphinx doc generation
     """
 
-    def __init__(self, core_path, path, log):
+    def __init__(self, core_path, path, log, additional_paths=None):
         """
         :param core_path: Path to tk-core. If None, the core API will
                           not be added to the pythonpath.
         :param path: Path to the app/engine/fw to document
         :param log: Logger
+        :param additional_paths: Additional file paths to prepend to the PYTHONPATH and sys.path
         """
         self._log = log
         self._path = path
@@ -69,11 +70,16 @@ class SphinxProcessor(object):
         # add main bundle location
         self._add_to_pythonpath(path)
 
-        # Add python location for the hooks.
+        # add python location for the hooks.
         self._add_to_pythonpath(os.path.join(path, "hooks"))
 
-        # and python location for bundle
+        # add python location for bundle
         self._add_to_pythonpath(os.path.join(path, "python"))
+
+        # add any additional paths specified
+        additional_paths = additional_paths or []
+        for additional_path in additional_paths:
+            self._add_to_pythonpath(additional_path)
 
         # check that Sphinx and PySide are available
         if core_path:

--- a/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_processor.py
+++ b/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_processor.py
@@ -114,7 +114,9 @@ class SphinxProcessor(object):
         self._log.debug("Added to PYTHONPATH: %s" % path)
         os.environ["PYTHONPATH"] = os.path.pathsep.join(pythonpath)
 
-    def build_docs(self, name, version, warnings_as_errors=True, additional_static_paths=None):
+    def build_docs(
+        self, name, version, warnings_as_errors=True, additional_static_paths=None
+    ):
         """
         Generate sphinx docs
 
@@ -133,15 +135,18 @@ class SphinxProcessor(object):
         # run build command
         # Use double quotes to make sure it works on Windows and Unix.
         # -T means show traceback
-        cmd = '%s -m sphinx -c "%s" %s -T -E -D project="%s" -D release="%s" -D version="%s" "%s" "%s"' % (
-            sys.executable,
-            self._sphinx_conf_py_location,
-            warnings_as_errors_flag,
-            name,
-            version,
-            version,
-            self._docs_path,
-            self._sphinx_build_dir,
+        cmd = (
+            '%s -m sphinx -c "%s" %s -T -E -D project="%s" -D release="%s" -D version="%s" "%s" "%s"'
+            % (
+                sys.executable,
+                self._sphinx_conf_py_location,
+                warnings_as_errors_flag,
+                name,
+                version,
+                version,
+                self._docs_path,
+                self._sphinx_build_dir,
+            )
         )
 
         execute_command(self._log, cmd)
@@ -153,7 +158,7 @@ class SphinxProcessor(object):
         # Creating .nojekyll file. This is cross platform. os.touch is not.
         with open(no_jekyll, "wt"):
             pass
-    
+
         # Copy additional static files to the build output
         additional_static_paths = additional_static_paths or []
         # Get the build output dir for html static files. This is the folder defined in conf.py

--- a/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_processor.py
+++ b/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_processor.py
@@ -70,11 +70,15 @@ class SphinxProcessor(object):
         # add main bundle location
         self._add_to_pythonpath(path)
 
-        # add python location for the hooks.
-        self._add_to_pythonpath(os.path.join(path, "hooks"))
-
-        # add python location for bundle
-        self._add_to_pythonpath(os.path.join(path, "python"))
+        # add all bundle subfolders - ignore the __pycache__ folder and hidden items (start with '.')
+        bundle_items = os.listdir(path)
+        for item_name in bundle_items:
+            if (
+                os.path.isdir(item_name)
+                and not item_name == "__pycache__"
+                and not item_name.startswith(".")
+            ):
+                self._add_to_pythonpath(os.path.join(path, item_name))
 
         # add any additional paths specified
         additional_paths = additional_paths or []

--- a/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_processor.py
+++ b/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_processor.py
@@ -114,12 +114,13 @@ class SphinxProcessor(object):
         self._log.debug("Added to PYTHONPATH: %s" % path)
         os.environ["PYTHONPATH"] = os.path.pathsep.join(pythonpath)
 
-    def build_docs(self, name, version, warnings_as_errors=True):
+    def build_docs(self, name, version, warnings_as_errors=True, additional_static_paths=None):
         """
         Generate sphinx docs
 
         :param name: The name to give to the documentation
         :param version: The version number to associate with the documentation
+        :param additional_static_paths: Additional static paths to add to the build output.
         :returns: Path to the built docs
         """
         self._log.debug("Building docs with name %s and version %s" % (name, version))
@@ -152,6 +153,14 @@ class SphinxProcessor(object):
         # Creating .nojekyll file. This is cross platform. os.touch is not.
         with open(no_jekyll, "wt"):
             pass
+    
+        # Copy additional static files to the build output
+        additional_static_paths = additional_static_paths or []
+        # Get the build output dir for html static files. This is the folder defined in conf.py
+        # as the html_static_path ("_static").
+        static_path_build_dir = os.path.join(self._sphinx_build_dir, "_static")
+        for static_path in additional_static_paths:
+            self.copy_docs(self._log, static_path, static_path_build_dir)
 
         return self._sphinx_build_dir
 

--- a/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_processor.py
+++ b/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_processor.py
@@ -70,12 +70,14 @@ class SphinxProcessor(object):
         # add main bundle location
         self._add_to_pythonpath(path)
 
-        # add all bundle subfolders - ignore the __pycache__ folder and hidden items (start with '.')
+        # add all bundle subfolders - ignore hidden items (those that start with '.') and
+        # ignore the specified list of folders that we know we won't need to generate docs from
+        ignore_folders = ["__pycache__", "docs", "tests", "resources"]
         bundle_items = os.listdir(path)
         for item_name in bundle_items:
             if (
-                os.path.isdir(item_name)
-                and not item_name == "__pycache__"
+                os.path.isdir(os.path.join(path, item_name))
+                and item_name not in ignore_folders
                 and not item_name.startswith(".")
             ):
                 self._add_to_pythonpath(os.path.join(path, item_name))


### PR DESCRIPTION
**Two changes:**

(1) If the bundle whose docs are being generated has a `docs/_static` folder, copy this folder's contents to the build output `html_static_path`

We need this for tk-alias because currently we include pre-compiled Sphinx documentation for the Alias Python API module, which is statically linked from the tk-alias docs, thus we need to include it in the build output static folder

(2) Include additional folders to prepend to the PYTHONPATH and sys.path -- so that sphinx can generate docs from code at those filepaths

We need this to generate docs for tk-alias to include path `tk-alias/api` since we store our third party Alias Python API python module at this location

**There are two ways we can do (2)**

a. By default, add all top-level folders in the bundle directory to the PYTHONPATH and sys.path (excluding hidden folders ".", and folders we know we don't need docs for, e.g. "test", "resources", "docs"

b. Allow user to optionally specify cmd line option to prepend additional paths to PYTHONPATH and sys.path so that Sphinx can generate docs for code found at those paths

**Option (b)** is less risky, since we're not adding unnecessary paths to the PYTHONPATH and sys.path -- just the ones we specify, but it also requires passing this command line arg at build time -- which we can do for Azure Pipelines build by editing the azure-pipelines.yml file, but for the rundeck job that publishes the docs, I could not find where we could set the env var.

Both options are currently included in the change.