### PR TITLE
Fix adding EAF docs/_static path to copy contents to output bundle

### DIFF
--- a/tk_toolchain/cmd_line_tools/tk_docs_generation/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_docs_generation/__init__.py
@@ -81,14 +81,9 @@ def preview_docs(
         "the release script, the proper github details will be extracted."
     )
 
-    additional_static_paths = []
-    bundle_static_path = os.path.join(bundle_path, "docs", "_static")
-    if os.path.exists(bundle_static_path):
-        additional_static_paths.append(bundle_static_path)
-
     # build docs
     location = sphinx_processor.build_docs(
-        doc_name, "vX.Y.Z", warnings_as_errors, additional_static_paths
+        doc_name, "vX.Y.Z", warnings_as_errors
     )
 
     if not is_build_only:

--- a/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_processor.py
+++ b/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_processor.py
@@ -177,7 +177,7 @@ class SphinxProcessor(object):
         # as the html_static_path ("_static").
         static_path_build_dir = os.path.join(self._sphinx_build_dir, "_static")
         for static_path in additional_static_paths:
-            self._log.debug("Copying contents from additiona static path: %s" % static_path)
+            self._log.debug("Adding additional path to copy to _static directory: %s" % static_path)
             self.copy_docs(self._log, static_path, static_path_build_dir)
 
         return self._sphinx_build_dir

--- a/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_processor.py
+++ b/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_processor.py
@@ -167,10 +167,17 @@ class SphinxProcessor(object):
 
         # Copy additional static files to the build output
         additional_static_paths = additional_static_paths or []
+        # add the app/engine/fw docs/_static path (if it exists) to the additional static paths
+        # to copy
+        bundle_static_path = os.path.join(self._path, "docs", "_static")
+        if os.path.exists(bundle_static_path):
+            additional_static_paths.append(bundle_static_path)
+
         # Get the build output dir for html static files. This is the folder defined in conf.py
         # as the html_static_path ("_static").
         static_path_build_dir = os.path.join(self._sphinx_build_dir, "_static")
         for static_path in additional_static_paths:
+            self._log.debug("Copying contents from additiona static path: %s" % static_path)
             self.copy_docs(self._log, static_path, static_path_build_dir)
 
         return self._sphinx_build_dir


### PR DESCRIPTION
* Do not add the path in the preview function - this will not carry over to the rundeck job
* Add the bundle's docs/_static path at the time of building the docs
* Leave the function param to pass any additional static paths if desired - default will be None