### PR TITLE
Swapping out any occurrence of micro-opt, with micro-basic in Tealium script.

### DIFF
--- a/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_data/_templates/layout.html
+++ b/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_data/_templates/layout.html
@@ -90,7 +90,7 @@
   <script type="text/javascript">
     window.wafCCPAForceShow = true;
     (function(a,b,c,d){
-      a='https://tags.tiqcdn.com/utag/autodesk/micro-opt/prod/utag.js';
+      a='https://tags.tiqcdn.com/utag/autodesk/micro-basic/prod/utag.js';
       b=document;c='script';d=b.createElement(c);d.src=a;d.type='text/java'+c;d.async=true;
       a=b.getElementsByTagName(c)[0];a.parentNode.insertBefore(d,a);
     })();


### PR DESCRIPTION
This PR fixes the flicker occurring on the developer.shotgunsoftware occurred after the Tealium implementation, swapping out any occurrence of micro-opt, with micro-basic in Tealium script, also removes an extra < /p> tag.