### PR TITLE
Build_error_due_to_importlib-metadata_latest_version_remove_deprecated_endpoint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,13 +23,6 @@ def read_file(fname):
 
     :returns: The text content.
     """
-
-    # import sys
-    # sys.path.append(
-    #     r"/Applications/PyCharm.app/Contents/debug-eggs/pydevd-pycharm.egg")
-    # import pydevd
-    # pydevd.settrace('localhost', port=5490, stdoutToServer=True,
-    #                 stderrToServer=True)
     file_path = os.path.join(os.path.dirname(__file__), fname)
     with codecs.open(file_path, encoding="utf-8") as fh:
         return fh.read()

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ is_python_27_or_greater = python_version >= (2, 7)
 is_python_27 = python_version == (2, 7)
 
 pytest_version = "pytest==4.6.6" if is_python_27_or_greater else "pytest<3.3"
-importlib_version = "importlib-metadata==4.13.0" if is_python_3 else ""
+importlib_version = "importlib-metadata>=4.4,<5.0.*" if is_python_3 else ""
 pytest_cov_version = (
     "pytest-cov==2.6.1" if is_python_27_or_greater else "pytest-cov==2.5.1"
 )

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,13 @@ def read_file(fname):
 
     :returns: The text content.
     """
+
+    # import sys
+    # sys.path.append(
+    #     r"/Applications/PyCharm.app/Contents/debug-eggs/pydevd-pycharm.egg")
+    # import pydevd
+    # pydevd.settrace('localhost', port=5490, stdoutToServer=True,
+    #                 stderrToServer=True)
     file_path = os.path.join(os.path.dirname(__file__), fname)
     with codecs.open(file_path, encoding="utf-8") as fh:
         return fh.read()
@@ -78,6 +85,9 @@ setup(
         # Tests
         pytest_version,
         pytest_cov_version,
+        # Locking importlib-metadata because the latest release v5.0.0
+        # remove deprecated endpoint.
+        "importlib-metadata==4.13.0",
         # Locking down these 3 tools to these specific versions is important
         # because we should use the same tools that tk-core ships with.
         "mock==2.0.0",

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ is_python_27_or_greater = python_version >= (2, 7)
 is_python_27 = python_version == (2, 7)
 
 pytest_version = "pytest==4.6.6" if is_python_27_or_greater else "pytest<3.3"
+importlib_version = "importlib-metadata==4.13.0" if is_python_3 else ""
 pytest_cov_version = (
     "pytest-cov==2.6.1" if is_python_27_or_greater else "pytest-cov==2.5.1"
 )
@@ -80,7 +81,7 @@ setup(
         pytest_cov_version,
         # Locking importlib-metadata because the latest release v5.0.0
         # remove deprecated endpoint.
-        "importlib-metadata==4.13.0",
+        importlib_version,  
         # Locking down these 3 tools to these specific versions is important
         # because we should use the same tools that tk-core ships with.
         "mock==2.0.0",

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ setup(
         pytest_cov_version,
         # Locking importlib-metadata because the latest release v5.0.0
         # remove deprecated endpoint.
-        importlib_version,  
+        importlib_version,
         # Locking down these 3 tools to these specific versions is important
         # because we should use the same tools that tk-core ships with.
         "mock==2.0.0",

--- a/tk_toolchain/cmd_line_tools/tk_docs_generation/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_docs_generation/__init__.py
@@ -82,9 +82,7 @@ def preview_docs(
     )
 
     # build docs
-    location = sphinx_processor.build_docs(
-        doc_name, "vX.Y.Z", warnings_as_errors
-    )
+    location = sphinx_processor.build_docs(doc_name, "vX.Y.Z", warnings_as_errors)
 
     if not is_build_only:
         # show in browser

--- a/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_processor.py
+++ b/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_processor.py
@@ -177,7 +177,9 @@ class SphinxProcessor(object):
         # as the html_static_path ("_static").
         static_path_build_dir = os.path.join(self._sphinx_build_dir, "_static")
         for static_path in additional_static_paths:
-            self._log.debug("Adding additional path to copy to _static directory: %s" % static_path)
+            self._log.debug(
+                "Adding additional path to copy to _static directory: %s" % static_path
+            )
             self.copy_docs(self._log, static_path, static_path_build_dir)
 
         return self._sphinx_build_dir


### PR DESCRIPTION
Update the importlib-metadata version to avoid the autoupdate to it´s lastest release v5.0.0 which it remove deprecated endpoint https://importlib-metadata.readthedocs.io/en/latest/history.html#v5-0-0.
