### PR TITLE
Update importlib-metada to a version below v5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ is_python_27_or_greater = python_version >= (2, 7)
 is_python_27 = python_version == (2, 7)
 
 pytest_version = "pytest==4.6.6" if is_python_27_or_greater else "pytest<3.3"
-importlib_version = "importlib-metadata==4.13.0" if is_python_3 else ""
+importlib_version = "importlib-metadata>=4.4,<5.0.*" if is_python_3 else ""
 pytest_cov_version = (
     "pytest-cov==2.6.1" if is_python_27_or_greater else "pytest-cov==2.5.1"
 )


### PR DESCRIPTION
Update the importlib-metadata version to avoid the autoupdate to it´s lastest release v5.0.0 which it remove deprecated endpoint https://importlib-metadata.readthedocs.io/en/latest/history.html#v5-0-0. Also fix a dependency conflict in the Rundeck