### PR TITLE
Update black to fix Azure Pipeline

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,7 +38,7 @@ repos:
       args: [--select=F]
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/ambv/black
-    rev: 22.3.0
+    rev: 23.3.0
     hooks:
     - id: black
       language_version: python3

--- a/tests/test_tk_config_update.py
+++ b/tests/test_tk_config_update.py
@@ -18,6 +18,7 @@ from ruamel import yaml
 
 from tk_toolchain.cmd_line_tools import tk_config_update
 
+
 # We'll create a copy of the config for this test so we can
 # run the tool on it without modifying it.
 @pytest.fixture(scope="module")

--- a/tk_toolchain/cmd_line_tools/tk_config_update/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_config_update/__init__.py
@@ -122,7 +122,7 @@ def enumerate_yaml_files(root):
 
     :returns: Iterator on all files ending with .yml.
     """
-    for (dirpath, _, filenames) in os.walk(root):
+    for dirpath, _, filenames in os.walk(root):
         for filename in filenames:
             filepath = os.path.join(dirpath, filename)
             if filepath.endswith(".yml"):
@@ -210,14 +210,12 @@ def update_files(repo_root, bundle, version):
     """
     # For every yml file in the repo
     for yml_file in enumerate_yaml_files(repo_root):
-
         # Load it and preserve the formatting
         with open(yml_file, "r") as fh:
             yaml_data = yaml.load(fh, yaml.RoundTripLoader)
 
         # If we found a descriptor to update
         if update_yaml_data(yaml_data, bundle, version):
-
             # Write back the changes and update the git index.
             with open(yml_file, "w") as fh:
                 yaml.dump(

--- a/tk_toolchain/cmd_line_tools/tk_docs_generation/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_docs_generation/__init__.py
@@ -96,7 +96,6 @@ def preview_docs(
 
 
 def main(arguments=None):
-
     arguments = arguments or sys.argv
 
     log.setLevel(logging.INFO)

--- a/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_processor.py
+++ b/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_processor.py
@@ -199,7 +199,6 @@ class SphinxProcessor(object):
 
         names = os.listdir(src)
         for name in names:
-
             srcname = os.path.join(src, name)
             dstname = os.path.join(dst, name)
 


### PR DESCRIPTION
Update black as a tentative fix for 

```
Traceback (most recent call last):
  File "/home/vsts/.cache/pre-commit/repo4wxfptoa/py_env-python3/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/home/vsts/.cache/pre-commit/repo4wxfptoa/py_env-python3/lib/python3.7/site-packages/black.py", line 4134, in patched_main
    patch_click()
  File "/home/vsts/.cache/pre-commit/repo4wxfptoa/py_env-python3/lib/python3.7/site-packages/black.py", line 4123, in patch_click
    from click import _unicodefun  # type: ignore
ImportError: cannot import name '_unicodefun' from 'click' (/home/vsts/.cache/pre-commit/repo4wxfptoa/py_env-python3/lib/python3.7/site-packages/click/__init__.py)
``` 

https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/results?buildId=8902&view=logs&j=5a2ace0f-23aa-5b6e-f4b4-e79a4d67f12b&t=e5ca1ff2-0538-5bc7-3cf0-bef50083dcac