### PR TITLE
SG-30910 Support latest version of Sphinx

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,6 @@ jobs:
     # Tell the build system that we want to pip install tk-toolchain
     # from the current branch.
     tk_toolchain_ref: $(Build.SourceBranch)
-    tk_core_ref: ticket/SG-30910_upgrade_sphinx  # REMOVE ME before merge
     # These extra repositories are required to test some of the command line tools
     additional_repositories:
     - name: tk-framework-shotgunutils

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,6 +40,7 @@ jobs:
     # Tell the build system that we want to pip install tk-toolchain
     # from the current branch.
     tk_toolchain_ref: $(Build.SourceBranch)
+    tk_core_ref: ticket/SG-30910_upgrade_sphinx  # REMOVE ME before merge
     # These extra repositories are required to test some of the command line tools
     additional_repositories:
     - name: tk-framework-shotgunutils

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import sys
 import codecs
 from setuptools import setup, find_packages
 
@@ -71,7 +72,7 @@ setup(
         "coverage==7.2.7",
         # Doc generation
         "PyYAML",
-        "sphinx==7.0.0",
+        "sphinx==7.0.0" if sys.version_info[0:2] >= (3, 9) else "sphinx==5.3.0",
         "sphinx_rtd_theme==1.3.0",
         "docopt==0.6.2",
         "six==1.14.0",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def read_file(fname):
 
 setup(
     name="tk-toolchain",
-    version="0.2.0.dev",
+    version="0.2.1.dev",
     author="Autodesk",
     author_email="https://developer.shotgridsoftware.com",
     maintainer="Autodesk",
@@ -65,21 +65,16 @@ setup(
         # Tests
         "pytest==7.4.2",
         "pytest-cov==4.1.0",
-        # Locking down these 3 tools to these specific versions is important
+        # Locking down these 2 tools to these specific versions is important
         # because we should use the same tools that tk-core ships with.
         "mock==5.1.0",
-        "coverage==7.2.7",  # supports Python 3.7
+        "coverage==7.2.7",
         # Doc generation
         "PyYAML",
-        # Use the latest version of Sphinx that supports Python 2 and 3.
-        # We have some rendering issues on Sphinx 2, notably bullet list in .rst items
-        # get rendered to html without the * in front.
-        "sphinx==1.8.5",
-        "sphinx_rtd_theme==0.4.3",
+        "sphinx==7.0.0",
+        "sphinx_rtd_theme==1.3.0",
         "docopt==0.6.2",
         "six==1.14.0",
-        # Lock down docutils because 0.18 break the build.
-        "docutils==0.17.1",
         # Lock down jinja because 3.1.0 breaks the build.
         "jinja2==3.0.3",
         # Other tools used by devs that are useful to have.

--- a/tk_toolchain/cmd_line_tools/tk_docs_generation/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_docs_generation/__init__.py
@@ -192,18 +192,20 @@ to type "tk-docs-preview" to preview the documentation.
             return 0
 
         # Make sure Qt is available if we're dealing with Toolkit repos.
-        if not repo.is_python_api():
+        if not repo.is_python_api() and not repo.is_sg_jira_bridge():
             try:
-                import PySide  # noqa
+                import PySide2  # noqa
             except ImportError:
                 try:
-                    import PySide2  # noqa testing importability, ignore unused import
+                    import PySide6  # noqa
                 except ImportError:
-                    log.error(
-                        "PySide or PySide2 are required to build the documentation."
-                    )
-                    return 1
-
+                    try:
+                        import PySide  # noqa
+                    except ImportError:
+                        log.error(
+                            "PySide, PySide2, or PySide6 are required to build the documentation."
+                        )
+                        return 1
         # If the specified the core path, we'll use it.
         if options.core:
             core_path = util.expand_path(options.core)

--- a/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_data/conf.py
+++ b/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_data/conf.py
@@ -212,7 +212,7 @@ release = "vX.Y.Z"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -365,9 +365,10 @@ htmlhelp_basename = "tkdoc"
 # external references. This allows for proper cross referencing between bundles
 # and extrnal libs
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/2", None),
+    "python": ("https://docs.python.org/3.9", None), 
     "PySide": ("http://pyside.github.io/docs/pyside/", None),
-    "PySide2": ("https://doc.qt.io/qtforpython", None),
+    "PySide2": ("https://doc.qt.io/qtforpython-5", None),
+    "PySide6": ("https://doc.qt.io/qtforpython", None),
     "sgtk": ("http://developer.shotgridsoftware.com/tk-core/", None),
     "tk-framework-qtwidgets": (
         "http://developer.shotgridsoftware.com/tk-framework-qtwidgets/",

--- a/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_data/conf.py
+++ b/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_data/conf.py
@@ -365,7 +365,7 @@ htmlhelp_basename = "tkdoc"
 # external references. This allows for proper cross referencing between bundles
 # and extrnal libs
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.9", None), 
+    "python": ("https://docs.python.org/3.9", None),
     "PySide": ("http://pyside.github.io/docs/pyside/", None),
     "PySide2": ("https://doc.qt.io/qtforpython-5", None),
     "PySide6": ("https://doc.qt.io/qtforpython", None),

--- a/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_data/conf.py
+++ b/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_data/conf.py
@@ -368,7 +368,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3.9", None),
     "PySide": ("http://pyside.github.io/docs/pyside/", None),
     "PySide2": ("https://doc.qt.io/qtforpython-5", None),
-    "PySide6": ("https://doc.qt.io/qtforpython", None),
+    "PySide6": ("https://doc.qt.io/qtforpython-6", None),
     "sgtk": ("http://developer.shotgridsoftware.com/tk-core/", None),
     "tk-framework-qtwidgets": (
         "http://developer.shotgridsoftware.com/tk-framework-qtwidgets/",

--- a/tk_toolchain/repo.py
+++ b/tk_toolchain/repo.py
@@ -177,7 +177,7 @@ class Repository(object):
         :returns: ``True`` is the repository is for the Python API, ``False`` otherwise.
         """
         return self._folder_contains("shotgun_api3")
-    
+
     def is_sg_jira_bridge(self):
         """
         Check if the repository is for the Jira Bridge

--- a/tk_toolchain/repo.py
+++ b/tk_toolchain/repo.py
@@ -177,6 +177,14 @@ class Repository(object):
         :returns: ``True`` is the repository is for the Python API, ``False`` otherwise.
         """
         return self._folder_contains("shotgun_api3")
+    
+    def is_sg_jira_bridge(self):
+        """
+        Check if the repository is for the Jira Bridge
+
+        :returns: ``True`` is the repository is for the Jira Bridge, ``False`` otherwise.
+        """
+        return self._folder_contains("sg_jira")
 
     def _folder_contains(self, filename):
         """


### PR DESCRIPTION
- Bump `sphinx` and `sphinx_rtd_theme` to the latest versions.
- Update comments.
- Remove `docutils` pin version because the latest version of sphinx now supports it.
- Add validation when generation sg-jira-bridge documentation. It should not check the presence of PySide.
- Support PySide6 in the validation message.
- Provide a language on Sphinx conf.py as recommended by the authors.
- Upgrade Sphinx external references to link Python 3 documentation pages instead of Python 2 pages.