### PR TITLE
SG-33641 Fix whitespace for long lines

### DIFF
--- a/tk_toolchain/cmd_line_tools/tk_config_update/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_config_update/__init__.py
@@ -221,6 +221,7 @@ def update_files(repo_root, bundle, version):
             with open(yml_file, "w") as fh:
                 _yaml = yaml.YAML()
                 _yaml.default_flow_style = False
+                _yaml.width = 500
                 _yaml.dump(yaml_data, fh)
             yield yml_file
 


### PR DESCRIPTION
It seems ruamel.yaml has a default width for 80 characters ([hint](https://sourceforge.net/p/ruamel-yaml/tickets/427/)). Long strings are broken at unbreakable words (such as URLs) affecting our current config yamls like this one: https://github.com/shotgunsoftware/tk-config-basic/commit/e2543b9bdd871e6ec156a2aaf4f0f9329028565e

Adding a bigger width attempt to fix this.

```py
data = {"foo.bar.baz.help_url": "https://help.autodesk.com/view/SGSUB/ENU/?guid=SG_Supervisor_Artist_sa_integrations_sa_integrations_user_guide_html#the-publisher", "foo.bar.baz.location": {"foo": "bar"}, }
_yaml = yaml.YAML()
_yaml.width = 256
_yaml.dump(data, sys.stdout)
```

Result:
```
foo.bar.baz.help_url: https://help.autodesk.com/view/SGSUB/ENU/?guid=SG_Supervisor_Artist_sa_integrations_sa_integrations_user_guide_html#the-publisher
foo.bar.baz.location:
  foo: bar
```

Dry run test: 

<img width="990" alt="image" src="https://github.com/shotgunsoftware/tk-toolchain/assets/123113322/b61eb435-77be-485f-ac7e-fdeea6376ecb">
