### PR TITLE
SG-33500 Yml config accepted to read from each repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,22 +297,46 @@ Toolkit Build Qt resources
 Compile Qt interface and resource files with a specified PySide compiler.
 
 Usage:
-    tk-build-qt-resources (-p <pyenv> | [-u <uic>] [-r <rcc>]) -q <qtuipath> -py <pybuiltpath> -uf <uifiles>... -rf <resfiles>... [-i <importtext>]
+    tk-build-qt-resources [-y <yamlfile>] (-p <pyenv> | [-u <uic>] [-r <rcc>])
 
 Options:
+    -y --yamlfile   The path to the YAML file with commands.
+    -p --pyenv      The Python environment path.
     -u --uic        The PySide uic compiler.
     -r --rcc        The PySide rcc compiler.
-    -p --pyenv      The Python environment path.
-    -q --qtuipath   The path with Qt .ui files.
-    -py --pybuiltpath The path to output all built .py files.
-    -uf --uifiles   The Qt .ui files to compile.
-    -rf --resfiles  The Qt .qrc resource files to compile.
-    -i --importtext The import text to replace (default is "tank.platform.qt").
 
 Examples:
-    tkbuild-qt-resources -u /path/to/pyside2-uic -r /path/to/pyside2-rcc -q /path/to/qt/ui/files -py /path/to/output/py/files -uf file1 file2 -rf resource1 resource2 -i custom.import.path
+    tk-build-qt-resources
 
-    tkbuild-qt-resources -p /path/to/python/env -q /path/to/qt/ui/files -py /path/to/output/py/files -uf file1 file2 -rf resource1 resource2 -i custom.import.path
+    tk-build-qt-resources -y name_of_yml_file_with_commands.yml
+
+    tk-build-qt-resources -p /path/to/python/env
+
+    tk-build-qt-resources -u /path/to/pyside2-uic -r /path/to/pyside2-rcc
+```
+
+And then it is going to be necessary to have a 'build_resources.yml' file in each repository.
+So this YAML file defines the configuration for building Qt UI and resource files using the tk-build-qt-resources script.
+Each entry in the file represents a separate build configuration with the following fields:
+
+- `ui_src`: The source directory containing the Qt .ui files.
+- `ui_files`: A list of .ui file names (without extensions) to compile.
+- `new_names_ui_files`: (Optional) A list of new names for the compiled .ui files (without extensions).
+                      If not provided, the original names will be used.
+- `res_files`: A list of .qrc resource file names (without extensions) to compile.
+- `py_dest`: (Optional) The destination directory where the compiled .py files will be placed,
+           (default is same directory of 'ui_src').
+- `import_pattern`: (Optional) The import text pattern to replace (default is ".").
+
+Example:
+```
+- ui_src: path/to/ui_files
+  ui_files:
+    - main_window
+  res_files:
+    - resources
+  py_dest: path/to/output
+  import_pattern: custom.import.path
 ```
 
 # FAQ

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ Each entry in the file represents a separate build configuration with the follow
 - `res_files`: A list of .qrc resource file names (without extensions) to compile.
 - `py_dest`: (Optional) The destination directory where the compiled .py files will be placed,
            (default is same directory of 'ui_src').
-- `import_pattern`: (Optional) The import text pattern to replace (default is ".").
+- `import_pattern`: (Optional) The import text pattern to replace (default is "tank.platform.qt").
 
 Example:
 ```

--- a/tk_toolchain/cmd_line_tools/tk_build_qt_resources/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_build_qt_resources/__init__.py
@@ -27,9 +27,9 @@ Examples:
 
     tk-build-qt-resources -y name_of_yml_file_with_commands.yml
 
-    tk-build-qt-resources -y name_of_yml_file_with_commands.yml -p /path/to/python/env
+    tk-build-qt-resources -p /path/to/python/env
 
-    tk-build-qt-resources -y name_of_yml_file_with_commands.yml -u /path/to/pyside2-uic -r /path/to/pyside2-rcc
+    tk-build-qt-resources -u /path/to/pyside2-uic -r /path/to/pyside2-rcc
 """
 
 import argparse
@@ -108,10 +108,10 @@ def run_yaml_commands(yaml_file, uic, rcc):
     yaml = YAML()
     yaml_commands = yaml.load(open(build_absolute_path(yaml_file)))
 
-    for command_set in yaml_commands:
+    for index, command_set in enumerate(yaml_commands, 1):
         ui_src = command_set.get("ui_src")
         if not ui_src:
-            print("'ui_src' is required in yml config")
+            print(f"'ui_src' is required in yml config {index}")
             return 1
 
         build_params = {
@@ -150,6 +150,8 @@ def run_yaml_commands(yaml_file, uic, rcc):
             build_qt_params = build_res(**build_params_res_files)
             build_qt(**build_qt_params)
 
+    return 1
+
 
 def main():
     parser = argparse.ArgumentParser(description="Build UI and resource files")
@@ -158,7 +160,7 @@ def main():
     parser.add_argument(
         "-p",
         "--pyenv",
-        default=os.getenv("PYTHONPATH", "/usr/bin/"),
+        default=os.getenv("PYTHONPATH"),
         help="The Python environment path",
     )
     parser.add_argument(
@@ -188,4 +190,4 @@ def main():
             return 1
         print(f"Using PySide compiler version: {version}")
 
-    run_yaml_commands(args.yamlfile, args.uic, args.rcc)
+    return run_yaml_commands(args.yamlfile, args.uic, args.rcc)

--- a/tk_toolchain/cmd_line_tools/tk_build_qt_resources/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_build_qt_resources/__init__.py
@@ -37,8 +37,15 @@ Examples:
 """
 
 import argparse
+import os
 import re
 import subprocess
+
+from ruamel.yaml import YAML
+
+# Set the Python environment variable. If 'PYTHONPATH' is not set, use the default path "/usr/bin/"
+# or you can override the Python environment path for a specific virtual environment
+PYTHON_ENV = os.getenv("PYTHONPATH", "/usr/bin/")
 
 
 def process_import_line(module, import_text):
@@ -59,7 +66,6 @@ def verify_compiler(compiler):
 
 
 def build_qt(compiler, py_filename, py_built_path, import_text):
-    print(f"The import text to replace will be '{import_text}'")
     output_path = f"{py_built_path}/{py_filename}.py"
     subprocess.run(compiler.split(" "), stdout=open(output_path, "w"), check=True)
     content = open(output_path, "r").read()
@@ -99,28 +105,82 @@ def build_res(
     }
 
 
+def build_resources(**kwagrs):
+    build_params = {
+        "qt_ui_path": kwagrs.get("qtuipath"),
+        "py_built_path": kwagrs.get("pybuiltpath"),
+        "import_text": kwagrs.get("importtext"),
+    }
+
+    print("Building user interfaces...")
+    for index, ui_file in enumerate(kwagrs.get("uifiles")):
+        build_params_ui_files = {
+            **build_params,
+            "compiler": kwagrs.get("uic"),
+            "filename": ui_file,
+            "py_filename": kwagrs.get("uifilenames")[index] if kwagrs.get("uifilenames") else None,
+        }
+        build_qt_params = build_ui(**build_params_ui_files)
+        build_qt(**build_qt_params)
+
+    print("Building resources...")
+    for index, res_file in enumerate(kwagrs.get("resfiles")):
+        build_params_res_files = {
+            **build_params,
+            "compiler": kwagrs.get("rcc"),
+            "filename": res_file,
+            "py_filename": kwagrs.get("resfilenames")[index] if kwagrs.get("resfilenames") else None,
+        }
+        build_qt_params = build_res(**build_params_res_files)
+        build_qt(**build_qt_params)
+
+
+def run_yaml_commands(yaml_file, uic, rcc):
+    with open(yaml_file, 'r') as file:
+        yaml = YAML()
+        yaml_commands = yaml.load(file)
+
+    for command_set in yaml_commands:
+        qt_ui_path = command_set["ui_src"]
+        py_built_path = command_set["py_dest"]
+        import_text = command_set["import_pattern"]
+        ui_files = command_set.get("ui_files", [])
+        new_names_ui_files = command_set.get("new_names_ui_files", [])
+        res_files = command_set.get("res_files", [])
+        new_names_res_files = command_set.get("new_names_res_files", [])
+
+        build_resources(
+            qtuipath=qt_ui_path,
+            pybuiltpath=py_built_path,
+            importtext=import_text,
+            uic=uic,
+            uifiles=ui_files,
+            uifilenames=new_names_ui_files,
+            rcc=rcc,
+            resfiles=res_files,
+            resfilenames=new_names_res_files
+        )
+
+
 def main():
     parser = argparse.ArgumentParser(description="Build UI and resource files")
     parser.add_argument("-u", "--uic", help="The PySide uic compiler")
     parser.add_argument("-r", "--rcc", help="The PySide rcc compiler")
-    parser.add_argument("-p", "--pyenv", help="The Python environment path")
+    parser.add_argument("-p", "--pyenv", default=PYTHON_ENV, help="The Python environment path")
     parser.add_argument(
         "-q",
         "--qtuipath",
-        required=True,
         help="The path with resources Qt .ui files",
     )
     parser.add_argument(
         "-py",
         "--pybuiltpath",
-        required=True,
         help="The path to output all built .py files to",
     )
     parser.add_argument(
         "-uf",
         "--uifiles",
         nargs="+",
-        required=True,
         help="The Qt .ui files to compile.",
     )
     parser.add_argument(
@@ -133,7 +193,6 @@ def main():
         "-rf",
         "--resfiles",
         nargs="+",
-        required=True,
         help="The Qt .qrc resource files to compile.",
     )
     parser.add_argument(
@@ -147,6 +206,11 @@ def main():
         "--importtext",
         default="tank.platform.qt",
         help="The import text to replace",
+    )
+    parser.add_argument(
+        "-y",
+        "--yamlfile",
+        help="The path to the YAML file with commands",
     )
     args = parser.parse_args()
 
@@ -169,30 +233,18 @@ def main():
             return 1
         print(f"Using PySide compiler version: {version}")
 
-    build_params = {
-        "qt_ui_path": args.qtuipath,
-        "py_built_path": args.pybuiltpath,
-        "import_text": args.importtext,
-    }
+    if args.yamlfile:
+        run_yaml_commands(args.yamlfile, args.uic, args.rcc)
+        return 1
 
-    print("Building user interfaces...")
-    for index, ui_file in enumerate(args.uifiles):
-        build_params_ui_files = {
-            **build_params,
-            "compiler": args.uic,
-            "filename": ui_file,
-            "py_filename": args.uifilenames[index] if args.uifilenames else None,
-        }
-        build_qt_params = build_ui(**build_params_ui_files)
-        build_qt(**build_qt_params)
-
-    print("Building resources...")
-    for index, res_file in enumerate(args.resfiles):
-        build_params_res_files = {
-            **build_params,
-            "compiler": args.rcc,
-            "filename": res_file,
-            "py_filename": args.resfilenames[index] if args.resfilenames else None,
-        }
-        build_qt_params = build_res(**build_params_res_files)
-        build_qt(**build_qt_params)
+    build_resources(
+        qtuipath=args.qtuipath,
+        pybuiltpath=args.pybuiltpath,
+        importtext=args.importtext,
+        uic=args.uic,
+        uifiles=args.uifiles,
+        uifilenames=args.uifilenames,
+        rcc=args.rcc,
+        resfiles=args.resfiles,
+        resfilenames=args.resfilenames
+    )

--- a/tk_toolchain/cmd_line_tools/tk_build_qt_resources/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_build_qt_resources/__init__.py
@@ -36,6 +36,7 @@ import argparse
 import os
 import re
 import subprocess
+import sys
 
 from ruamel.yaml import YAML
 
@@ -108,16 +109,16 @@ def run_yaml_commands(yaml_file, uic, rcc):
     yaml = YAML()
     yaml_commands = yaml.load(open(build_absolute_path(yaml_file)))
 
-    for index, command_set in enumerate(yaml_commands, 1):
+    for command_set in yaml_commands:
         ui_src = command_set.get("ui_src")
         if not ui_src:
-            print(f"'ui_src' is required in yml config {index}")
-            return 1
+            print("'ui_src' is required in yml config")
+            sys.exit(1)
 
         build_params = {
             "qt_ui_path": build_absolute_path(ui_src),
             "py_built_path": build_absolute_path(command_set.get("py_dest", ui_src)),
-            "import_text": command_set.get("import_pattern", "."),
+            "import_text": command_set.get("import_pattern", "tank.platform.qt"),
         }
 
         print("Building user interfaces...")
@@ -190,4 +191,4 @@ def main():
             return 1
         print(f"Using PySide compiler version: {version}")
 
-    return run_yaml_commands(args.yamlfile, args.uic, args.rcc)
+    run_yaml_commands(args.yamlfile, args.uic, args.rcc)

--- a/tk_toolchain/cmd_line_tools/tk_build_qt_resources/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_build_qt_resources/__init__.py
@@ -118,7 +118,9 @@ def build_resources(**kwagrs):
             **build_params,
             "compiler": kwagrs.get("uic"),
             "filename": ui_file,
-            "py_filename": kwagrs.get("uifilenames")[index] if kwagrs.get("uifilenames") else None,
+            "py_filename": (
+                kwagrs.get("uifilenames")[index] if kwagrs.get("uifilenames") else None
+            ),
         }
         build_qt_params = build_ui(**build_params_ui_files)
         build_qt(**build_qt_params)
@@ -129,14 +131,18 @@ def build_resources(**kwagrs):
             **build_params,
             "compiler": kwagrs.get("rcc"),
             "filename": res_file,
-            "py_filename": kwagrs.get("resfilenames")[index] if kwagrs.get("resfilenames") else None,
+            "py_filename": (
+                kwagrs.get("resfilenames")[index]
+                if kwagrs.get("resfilenames")
+                else None
+            ),
         }
         build_qt_params = build_res(**build_params_res_files)
         build_qt(**build_qt_params)
 
 
 def run_yaml_commands(yaml_file, uic, rcc):
-    with open(yaml_file, 'r') as file:
+    with open(yaml_file, "r") as file:
         yaml = YAML()
         yaml_commands = yaml.load(file)
 
@@ -158,7 +164,7 @@ def run_yaml_commands(yaml_file, uic, rcc):
             uifilenames=new_names_ui_files,
             rcc=rcc,
             resfiles=res_files,
-            resfilenames=new_names_res_files
+            resfilenames=new_names_res_files,
         )
 
 
@@ -166,7 +172,9 @@ def main():
     parser = argparse.ArgumentParser(description="Build UI and resource files")
     parser.add_argument("-u", "--uic", help="The PySide uic compiler")
     parser.add_argument("-r", "--rcc", help="The PySide rcc compiler")
-    parser.add_argument("-p", "--pyenv", default=PYTHON_ENV, help="The Python environment path")
+    parser.add_argument(
+        "-p", "--pyenv", default=PYTHON_ENV, help="The Python environment path"
+    )
     parser.add_argument(
         "-q",
         "--qtuipath",
@@ -246,5 +254,5 @@ def main():
         uifilenames=args.uifilenames,
         rcc=args.rcc,
         resfiles=args.resfiles,
-        resfilenames=args.resfilenames
+        resfilenames=args.resfilenames,
     )


### PR DESCRIPTION
- Yml config accepted to read from each repo.
- Possible ways to run the command after a pip installation "pip install tk-toolchain" and set PYTHONPATH with the python environment path where has to exists pyside2-uic and pyside2-rcc compilers:
```
    >  tk-build-qt-resources

    >  tk-build-qt-resources -y name_of_yml_file_with_commands.yml

    >  tk-build-qt-resources -y name_of_yml_file_with_commands.yml -p /path/to/python/env

    >  tk-build-qt-resources -y name_of_yml_file_with_commands.yml -u /path/to/pyside2-uic -r /path/to/pyside2-rcc
```