### PR TITLE
SG-33500 Changes from Julien from #65

### DIFF
--- a/tk_toolchain/cmd_line_tools/tk_build_qt_resources/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_build_qt_resources/__init__.py
@@ -115,11 +115,11 @@ def run_yaml_commands(yaml_file, uic, rcc):
         try:
             build_params = {
                 "qt_ui_path": build_absolute_path(yaml_file, command_set["ui_src"]),
-                "py_built_path": build_absolute_path(yaml_file, command_set["py_dest"]),
-                "import_text": command_set["import_pattern"],
+                "py_built_path": build_absolute_path(yaml_file, command_set.get("py_dest", command_set["ui_src"])),
+                "import_text": command_set.get("import_pattern", "."),
             }
         except KeyError:
-            print("'ui_src', 'py_dest' and 'import_pattern' are required in yml config")
+            print("'ui_src'is required in yml config")
             return 1
 
         print("Building user interfaces...")

--- a/tk_toolchain/cmd_line_tools/tk_build_qt_resources/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_build_qt_resources/__init__.py
@@ -163,8 +163,8 @@ def main():
     parser.add_argument(
         "-y",
         "--yamlfile",
-        required=True,
         help="The path to the YAML file with commands",
+        default="build_resources.yml"
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
Related to #65

Changes that I believe make things simpler.


I call the script from the TK git repo for which I want to compile the resources:
```shell
PYTHONPATH=../tk-toolchain \
python3 -m tk_toolchain.cmd_line_tools.tk_build_qt_resources \
  -u /Applications/Shotgun.app/Contents/Resources/Python3/lib/python3.10/site-packages/PySide2/uic \
  -r /Applications/Shotgun.app/Contents/Resources/Python3/lib/python3.10/site-packages/PySide2/rcc
```

- `PYTHONPATH=../tk-toolchain` and `python3 -m tk_toolchain.cmd_line_tools.` will become useless if I `pip install tk-toolchain` but it's convenient to know
- the `-u` and `-r` values could be default since they match with the SGD installation folder.
