### PR TITLE
Fix flaxy tests caused by race condition on LocalStorage entity value

### DIFF
--- a/pytest_tank_test/__init__.py
+++ b/pytest_tank_test/__init__.py
@@ -9,8 +9,6 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-from __future__ import print_function
-
 from tk_toolchain.repo import Repository
 from tk_toolchain import util
 from tk_toolchain.tk_testengine import get_test_engine_environment

--- a/pytest_tank_test/tk_fixtures.py
+++ b/pytest_tank_test/tk_fixtures.py
@@ -47,6 +47,8 @@ def tk_test_project(tk_test_shotgun):
 
     :returns: Current project name and id
     """
+    import sgtk
+
     # Create or update the integration_tests local storage with the current test run.
     # Cannot use a unique name for storage_name because Workfiles2 automation
     # is using an advanced custom config and it has storage name harcoded in roots.yml
@@ -58,8 +60,17 @@ def tk_test_project(tk_test_shotgun):
         local_storage = tk_test_shotgun.create("LocalStorage", {"code": storage_name})
     # Always update local storage path
     local_storage["path"] = os.path.expandvars("${SHOTGUN_CURRENT_REPO_ROOT}")
+    if sgtk.util.is_windows():
+        storage_key = "windows_path"
+    elif sgtk.util.is_linux():
+        storage_key = "linux_path"
+    elif sgtk.util.is_macos():
+        storage_key = "mac_path"
+    else:
+        raise Exception("Unknown platform")
+
     tk_test_shotgun.update(
-        "LocalStorage", local_storage["id"], {"windows_path": local_storage["path"]}
+        "LocalStorage", local_storage["id"], {storage_key: local_storage["path"]}
     )
 
     # Make sure there is not already an automation project created

--- a/setup.py
+++ b/setup.py
@@ -66,16 +66,13 @@ setup(
         # Tests
         "pytest==7.4.2",
         "pytest-cov==4.1.0",
-        # Locking down these 2 tools to these specific versions is important
+        # Locking down coverage to a specific version is important
         # because we should use the same tools that tk-core ships with.
-        "mock==5.1.0",
         "coverage==7.2.7",
         # Doc generation
-        "PyYAML",
         "sphinx==7.0.0" if sys.version_info[0:2] >= (3, 9) else "sphinx==5.3.0",
         "sphinx_rtd_theme==1.3.0",
         "docopt==0.6.2",
-        "six==1.14.0",
         # Lock down jinja because 3.1.0 breaks the build.
         "jinja2==3.0.3",
         # Other tools used by devs that are useful to have.

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -10,7 +10,7 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import pytest
-from mock import Mock
+from unittest.mock import Mock
 
 
 from tk_toolchain.authentication import _get_toolkit_user

--- a/tests/test_tk_config_update.py
+++ b/tests/test_tk_config_update.py
@@ -11,7 +11,6 @@
 
 import os
 import subprocess
-import six
 
 import pytest
 from ruamel import yaml
@@ -30,14 +29,12 @@ def cloned_config(tk_config_root, tmpdir_factory):
     copy of the repository or because tk-config-basic is missing.
     """
     tmp_path = tmpdir_factory.mktemp("config")
-    # cast LocalPath to str since Python 2 compatible methods manipulate strings
-    tmp_path = str(tmp_path)
     # We're cloning version v1.6.1 to ensure the test doesn't fail due to a change
     # in the config.
     subprocess.check_call(
         ["git", "clone", "--depth", "1", "--branch", "v1.6.1", tk_config_root, tmp_path]
     )
-    return six.ensure_str(tmp_path)
+    return tmp_path
 
 
 @pytest.fixture

--- a/tests/test_tk_config_update.py
+++ b/tests/test_tk_config_update.py
@@ -28,7 +28,7 @@ def cloned_config(tk_config_root, tmpdir_factory):
     If this clone fails, it's likely because tag v1.6.1 is not in your
     copy of the repository or because tk-config-basic is missing.
     """
-    tmp_path = tmpdir_factory.mktemp("config")
+    tmp_path = str(tmpdir_factory.mktemp("config"))
     # We're cloning version v1.6.1 to ensure the test doesn't fail due to a change
     # in the config.
     subprocess.check_call(

--- a/tk_toolchain/cmd_line_tools/tk_config_update/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_config_update/__init__.py
@@ -27,18 +27,15 @@ Example:
     tk-config-update git@github.com:shotgunsoftware/tk-config-default2.git tk-core v0.19.0
 """
 
-import subprocess
-import sys
+import atexit
 import os
 import shutil
-import atexit
+import subprocess
+import sys
 import tempfile
-import docopt
 
-try:
-    from ruamel import yaml
-except ImportError:
-    sys.exit("This tool can only be run with Python 2.7 or greater.")
+import docopt
+from ruamel import yaml
 
 
 # FIXME: Maybe we should rename the other repository class (tk_toolchain.repo.Repository)

--- a/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_data/conf.py
+++ b/tk_toolchain/cmd_line_tools/tk_docs_generation/sphinx_data/conf.py
@@ -21,7 +21,6 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-from __future__ import print_function
 import logging
 import sys
 

--- a/tk_toolchain/tk_testengine/engine.py
+++ b/tk_toolchain/tk_testengine/engine.py
@@ -58,9 +58,7 @@ class TestEngine(sgtk.platform.Engine):
 
         See sgtk.platform.Engine documentation's for more details.
         """
-        dialog = super(self.__class__, self).show_dialog(
-            title, bundle, widget_class, *args, **kwargs
-        )
+        dialog = super().show_dialog(title, bundle, widget_class, *args, **kwargs)
         # Forces the dialog to show on top of other dialogs when using PySide 1
         dialog.window().raise_()
         dialog.window().show()


### PR DESCRIPTION
- Remove traces of Python 2
- Prevents race condition when running unit tests that update the value of the `LocalStorage` FPTR entity. It always used `windows_path`.

From this 
![image](https://github.com/user-attachments/assets/8881da2b-02ae-485a-b0df-4e39b560d020)

To this
![image](https://github.com/user-attachments/assets/783d6d0f-7747-493e-af3b-502eba8b643e)
