### PR TITLE
SG-38459 Replace docopt by argparse

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,6 @@ setup(
         # Doc generation
         "sphinx==7.0.0" if sys.version_info[0:2] >= (3, 9) else "sphinx==5.3.0",
         "sphinx_rtd_theme==1.3.0",
-        "docopt==0.6.2",
         # Lock down jinja because 3.1.0 breaks the build.
         "jinja2==3.0.3",
         # Other tools used by devs that are useful to have.

--- a/tk_toolchain/cmd_line_tools/tk_config_update/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_config_update/__init__.py
@@ -215,38 +215,42 @@ def main(arguments=None):
     """
 
     parser = argparse.ArgumentParser(
-        description="""
+        prog="tk_config_update",
+        description=textwrap.dedent(
+            """
             Toolkit Configuration Update
 
             Update the version of a bundle in a config to the specified version
             and pushes
-        """,
+            """
+        ),
         epilog=textwrap.dedent(
             """
             Example:
                 tk-config-update git@github.com:shotgunsoftware/tk-config-default2.git tk-core v0.19.0
-        """
+            """
         ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 
     parser.add_argument(
         "config",
-        description="URL to the TK config git repository to update",
+        help="URL to the TK config git repository to update",
     )
 
     parser.add_argument(
         "bundle",
-        description="Name of the TK component",
+        help="Name of the TK component",
     )
 
     parser.add_argument(
         "version",
-        description="Version of the TK component",
+        help="Version of the TK component",
     )
 
     parser.add_argument(
         "--push-changes",
-        description="""
+        help="""
             Pushes the changes to the repository. If not specified, the remote
             repository is not updated.
         """,

--- a/tk_toolchain/cmd_line_tools/tk_config_update/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_config_update/__init__.py
@@ -215,16 +215,18 @@ def main(arguments=None):
     """
 
     parser = argparse.ArgumentParser(
-        description = """
+        description="""
             Toolkit Configuration Update
 
             Update the version of a bundle in a config to the specified version
             and pushes
         """,
-        epilog = textwrap.dedent("""
+        epilog=textwrap.dedent(
+            """
             Example:
                 tk-config-update git@github.com:shotgunsoftware/tk-config-default2.git tk-core v0.19.0
-        """),
+        """
+        ),
     )
 
     parser.add_argument(
@@ -244,7 +246,7 @@ def main(arguments=None):
 
     parser.add_argument(
         "--push-changes",
-        description = """
+        description="""
             Pushes the changes to the repository. If not specified, the remote
             repository is not updated.
         """,
@@ -276,7 +278,9 @@ def main(arguments=None):
             "Updated {bundle} to {version}\n"
             "Release notes: https://github.com/shotgunsoftware/{bundle}/wiki/Release-Notes#{version_no_dots}"
         ).format(
-            bundle=args.bundle, version=args.version, version_no_dots=args.version.replace(".", "")
+            bundle=args.bundle,
+            version=args.version,
+            version_no_dots=args.version.replace(".", ""),
         )
     )
 

--- a/tk_toolchain/cmd_line_tools/tk_config_update/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_config_update/__init__.py
@@ -225,7 +225,6 @@ def main(arguments=None):
             Example:
                 tk-config-update git@github.com:shotgunsoftware/tk-config-default2.git tk-core v0.19.0
         """),
-
     )
 
     parser.add_argument(

--- a/tk_toolchain/cmd_line_tools/tk_run_app/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_run_app/__init__.py
@@ -46,7 +46,7 @@ import os
 import sys
 from pprint import pprint
 
-import docopt
+import docopt  # TODO here too!
 
 from tk_toolchain.repo import Repository
 from tk_toolchain import util, authentication

--- a/tk_toolchain/cmd_line_tools/tk_run_app/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_run_app/__init__.py
@@ -12,8 +12,9 @@
 
 import argparse
 import os
+import pprint
 import sys
-from pprint import pprint
+import textwrap
 
 from tk_toolchain.repo import Repository
 from tk_toolchain import util, authentication
@@ -137,7 +138,7 @@ def _get_available_commands(engine):
     )
 
     print("Available application commands (long and short versions):")
-    pprint(possible_commands)
+    pprint.pprint(possible_commands)
 
     return possible_commands, long_command_names
 
@@ -159,7 +160,7 @@ def _validate_requested_commands(commands, available_commands, long_command_name
 
     print("The following commands will be run:")
     if commands:
-        pprint(sorted(commands))
+        pprint.pprint(sorted(commands))
         return commands
     else:
         # Only print the long command names for clarity. Not every app has a short
@@ -177,12 +178,16 @@ def main(arguments=None):
     """
 
     parser = argparse.ArgumentParser(
-        description="""
+        prog="tk_run_app",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=textwrap.dedent(
+            """
             Toolkit Application Runner
 
             Launch a Toolkit application from the command line by running this
             tool in any Toolkit repository.
-        """,
+            """
+        ),
     )
 
     parser.add_argument(

--- a/tk_toolchain/cmd_line_tools/tk_run_app/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_run_app/__init__.py
@@ -177,7 +177,7 @@ def main(arguments=None):
     """
 
     parser = argparse.ArgumentParser(
-        description= """
+        description="""
             Toolkit Application Runner
 
             Launch a Toolkit application from the command line by running this
@@ -255,11 +255,7 @@ def main(arguments=None):
             if args.context_entity_type is not None
             else "Project"
         ),
-        (
-            int(args.context_entity_id)
-            if args.context_entity_id is not None
-            else None
-        ),
+        (int(args.context_entity_id) if args.context_entity_id is not None else None),
         config,
     )
 

--- a/tk_toolchain/cmd_line_tools/tk_run_app/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_run_app/__init__.py
@@ -10,43 +10,10 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-"""
-Toolkit Application Runner
-
-Launch a Toolkit application from the command line by running this tool in any
-Toolkit repository.
-
-Usage:
-    tk-run-app [--context-entity-type=<entity-type>] [--context-entity-id=<entity-id>] [--location=<location>] [--commands=<commands>] [--config=<config>]
-
-Options:
-
-    -e, --context-entity-type=<entity-type>
-                       Specifies the type of the entity of the context.
-
-    -i, --context-entity-id=<entity-id>
-                       Specifies the id of the entity of the context.
-
-    --location=<location>
-                        Specifies the location where the Toolkit application is.
-                        If missing, the tk-run-app assumes it is run from inside
-                        the repository and launch the application at the root of
-                        it.
-
-    --commands=<commands>
-                        Comma-separated list of commands to run. These can be long
-                        or short Toolkit command names. If missing, tk-run-app
-                        assumes all commands should be run.
-
-    -c, --config=<config>
-                        Specifies the location of the Toolkit config folder to use.
-"""
-
+import argparse
 import os
 import sys
 from pprint import pprint
-
-import docopt  # TODO here too!
 
 from tk_toolchain.repo import Repository
 from tk_toolchain import util, authentication
@@ -208,28 +175,71 @@ def main(arguments=None):
     This will launch all the Toolkit applications and panels registered at app init
     and wait until all of them have been closed.
     """
-    arguments = arguments or sys.argv[1:]
 
-    # docopt does not care about the script name, so skip or we'll
-    # get an error.
-    options = docopt.docopt(__doc__, argv=arguments)
+    parser = argparse.ArgumentParser(
+        description= """
+            Toolkit Application Runner
+
+            Launch a Toolkit application from the command line by running this
+            tool in any Toolkit repository.
+        """,
+    )
+
+    parser.add_argument(
+        "--context-entity-type",
+        "-e",
+        help="Specifies the type of the entity of the context",
+    )
+
+    parser.add_argument(
+        "--context-entity-id",
+        "-i",
+        help="Specifies the id of the entity of the context",
+    )
+
+    parser.add_argument(
+        "--location",
+        help="""
+            Specifies the location where the Toolkit application is.
+            If missing, the tk-run-app assumes it is run from inside
+            the repository and launch the application at the root of
+            it.
+        """,
+    )
+
+    parser.add_argument(
+        "--commands",
+        help="""
+            Comma-separated list of commands to run. These can be long
+            or short Toolkit command names. If missing, tk-run-app
+            assumes all commands should be run.
+        """,
+    )
+
+    parser.add_argument(
+        "--config",
+        "-c",
+        help="Specifies the location of the Toolkit config folder to use",
+    )
+
+    args = parser.parse_args(args=arguments)
 
     # Check to see if a Toolkit config location was passed and resolve any
     # environment variables in the path.
-    config = util.expand_path(options["--config"]) if options["--config"] else None
+    config = util.expand_path(args.config) if args.config else None
 
     if config and not os.path.exists(config):
         print("This config location does not exist. %s" % config)
         return 1
 
     # Find the current repo and add Toolkit to the PYTHONPATH so we ca import it.
-    repo = Repository(util.expand_path(options["--location"] or os.getcwd()))
+    repo = Repository(util.expand_path(args.location or os.getcwd()))
     tk_core = os.path.join(repo.parent, "tk-core", "python")
     sys.path.insert(0, tk_core)
 
-    if options["--commands"]:
+    if args.commands:
         commands_to_run = [
-            command.strip() for command in (options["--commands"] or "").split(",")
+            command.strip() for command in (args.commands or "").split(",")
         ]
     else:
         commands_to_run = []
@@ -241,13 +251,13 @@ def main(arguments=None):
     engine = _start_engine(
         repo,
         (
-            options["--context-entity-type"]
-            if options["--context-entity-type"] is not None
+            args.context_entity_type
+            if args.context_entity_type is not None
             else "Project"
         ),
         (
-            int(options["--context-entity-id"])
-            if options["--context-entity-id"] is not None
+            int(args.context_entity_id)
+            if args.context_entity_id is not None
             else None
         ),
         config,


### PR DESCRIPTION
Remove dependency to another third party Python library

New script's usage (same prototype):

## tk_config_update

```
$ python3 -m tk_toolchain.cmd_line_tools.tk_config_update -h
usage: tk_config_update [-h] [--push-changes] config bundle version

Toolkit Configuration Update

Update the version of a bundle in a config to the specified version
and pushes

positional arguments:
  config          URL to the TK config git repository to update
  bundle          Name of the TK component
  version         Version of the TK component

options:
  -h, --help      show this help message and exit
  --push-changes  Pushes the changes to the repository. If not specified, the remote
                  repository is not updated.

Example:
    tk-config-update git@github.com:shotgunsoftware/tk-config-default2.git tk-core v0.19.0
```


## tk_run_app

```
$ python3 -m tk_toolchain.cmd_line_tools.tk_run_app -h
usage: tk_run_app [-h] [--context-entity-type CONTEXT_ENTITY_TYPE] [--context-entity-id CONTEXT_ENTITY_ID] [--location LOCATION]
                  [--commands COMMANDS] [--config CONFIG]

Toolkit Application Runner

Launch a Toolkit application from the command line by running this
tool in any Toolkit repository.

options:
  -h, --help            show this help message and exit
  --context-entity-type CONTEXT_ENTITY_TYPE, -e CONTEXT_ENTITY_TYPE
                        Specifies the type of the entity of the context
  --context-entity-id CONTEXT_ENTITY_ID, -i CONTEXT_ENTITY_ID
                        Specifies the id of the entity of the context
  --location LOCATION   Specifies the location where the Toolkit application is. If missing, the tk-run-app assumes it is run from inside the
                        repository and launch the application at the root of it.
  --commands COMMANDS   Comma-separated list of commands to run. These can be long or short Toolkit command names. If missing, tk-run-app assumes all
                        commands should be run.
  --config CONFIG, -c CONFIG
                        Specifies the location of the Toolkit config folder to use
```

