### PR TITLE
SG-38694 Remove yaml deprecation warning

### DIFF
--- a/pytest_tank_test/__init__.py
+++ b/pytest_tank_test/__init__.py
@@ -154,7 +154,7 @@ def _ensure_dependencies(repo):
     # Read azure-pipelines.yml so we can search for test dependencies.
     with open(azurepipelines_yml_path, "rt") as fh:
         yaml = YAML()
-        azurepipelines_yml = yaml.load(fh)
+        azurepipelines_yml = yaml.load(fh, Loader=yaml.FullLoader)
 
     # Here's an example of an azure-pipelines.yml file.
     # jobs:

--- a/tests/test_tk_config_update.py
+++ b/tests/test_tk_config_update.py
@@ -127,11 +127,11 @@ def test_update_config(
 
     with open(os.path.join(cloned_config, modified_file), "rt") as fh:
         _yaml = yaml.YAML()
-        expected_cfg = _yaml.load(fh)
+        expected_cfg = _yaml.load(fh, Loader=yaml.FullLoader)
 
     with open(os.path.join(test_config, modified_file), "rt") as fh:
         _yaml = yaml.YAML()
-        test_config = _yaml.load(fh)
+        test_config = _yaml.load(fh, Loader=yaml.FullLoader)
 
     value = expected_cfg
     for key in path_to_descriptor:

--- a/tk_toolchain/cmd_line_tools/tk_build_qt_resources/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_build_qt_resources/__init__.py
@@ -107,7 +107,10 @@ def build_absolute_path(path_or_file):
 
 def run_yaml_commands(yaml_file, uic, rcc):
     yaml = YAML()
-    yaml_commands = yaml.load(open(build_absolute_path(yaml_file)))
+    yaml_commands = yaml.load(
+        open(build_absolute_path(yaml_file)),
+        Loader=yaml.FullLoader,
+    )
 
     for command_set in yaml_commands:
         ui_src = command_set.get("ui_src")

--- a/tk_toolchain/cmd_line_tools/tk_config_update/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_config_update/__init__.py
@@ -193,7 +193,7 @@ def update_files(repo_root, bundle, version):
         # Load it and preserve the formatting
         with open(yml_file, "r") as fh:
             _yaml = yaml.YAML()
-            yaml_data = _yaml.load(fh)
+            yaml_data = _yaml.load(fh, Loader=yaml.FullLoader)
 
         # If we found a descriptor to update
         if update_yaml_data(yaml_data, bundle, version):


### PR DESCRIPTION
Add `Loader=yaml.FullLoader` parameter to remove the following warning log:
```
YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
```