### PR TITLE
SG-33297 Fixups

### DIFF
--- a/tk_toolchain/cmd_line_tools/tk_build_qt_resources/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_build_qt_resources/__init__.py
@@ -60,7 +60,12 @@ def verify_compiler(compiler):
 
 def build_qt(compiler, py_filename, py_built_path, import_text):
     output_path = os.path.join(py_built_path, f"{py_filename}.py")
-    subprocess.run(compiler, stdout=open(output_path, "w"), check=True)
+    compiler.extend([
+        "--output",
+        output_path,
+    ])
+
+    subprocess.run(compiler, check=True)
     content = open(output_path, "r").read()
     content = re.sub(
         r"^from PySide2.QtWidgets(\s.*)?$", "", content, flags=re.MULTILINE

--- a/tk_toolchain/cmd_line_tools/tk_build_qt_resources/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_build_qt_resources/__init__.py
@@ -60,7 +60,7 @@ def verify_compiler(compiler):
 
 def build_qt(compiler, py_filename, py_built_path, import_text):
     output_path = os.path.join(py_built_path, f"{py_filename}.py")
-    subprocess.run(compiler.split(" "), stdout=open(output_path, "w"), check=True)
+    subprocess.run(compiler, stdout=open(output_path, "w"), check=True)
     content = open(output_path, "r").read()
     content = re.sub(
         r"^from PySide2.QtWidgets(\s.*)?$", "", content, flags=re.MULTILINE
@@ -80,7 +80,13 @@ def build_ui(
     compiler, qt_ui_path, py_built_path, import_text, filename, py_filename=None
 ):
     return {
-        "compiler": f"{compiler} -g python --from-imports {qt_ui_path}/{filename}.ui",
+        "compiler": [
+            compiler,
+            "-g",
+            "python",
+            "--from-imports",
+            f"{qt_ui_path}/{filename}.ui",
+        ],
         "py_filename": py_filename or filename,
         "py_built_path": py_built_path,
         "import_text": import_text,
@@ -91,7 +97,12 @@ def build_res(
     compiler, qt_ui_path, py_built_path, import_text, filename, py_filename=None
 ):
     return {
-        "compiler": f"{compiler} -g python {qt_ui_path}/{filename}.qrc",
+        "compiler": [
+            compiler,
+            "-g",
+            "python",
+            f"{qt_ui_path}/{filename}.qrc",
+        ],
         "py_filename": f"{py_filename or filename}_rc",
         "py_built_path": py_built_path,
         "import_text": import_text,

--- a/tk_toolchain/cmd_line_tools/tk_build_qt_resources/__init__.py
+++ b/tk_toolchain/cmd_line_tools/tk_build_qt_resources/__init__.py
@@ -161,7 +161,7 @@ def main():
     parser.add_argument(
         "-p",
         "--pyenv",
-        default=os.getenv("PYTHONPATH"),
+        default=os.getenv("PYENV_VIRTUAL_ENV", os.getenv("VIRTUAL_ENV")),
         help="The Python environment path",
     )
     parser.add_argument(
@@ -173,8 +173,8 @@ def main():
     args = parser.parse_args()
 
     if (not args.uic and not args.rcc) and args.pyenv:
-        args.uic = f"{args.pyenv}/pyside2-uic"
-        args.rcc = f"{args.pyenv}/pyside2-rcc"
+        args.uic = f"{args.pyenv}/bin/pyside2-uic"
+        args.rcc = f"{args.pyenv}/bin/pyside2-rcc"
 
     if not args.rcc or not args.uic:
         print(


### PR DESCRIPTION
This pull request refactors the `tk_build_qt_resources` module to improve the handling of compiler arguments and environment variables. The most important changes include switching from string-based command construction to list-based argument handling for subprocess calls, updating environment variable defaults, and refining paths for PySide2 tools.

### Refactoring compiler argument handling:

* [`tk_toolchain/cmd_line_tools/tk_build_qt_resources/__init__.py`](diffhunk://#diff-9967a30257c1f6bd43330bc7d3a12ef565823225c37e4a5df0af248d0ba66381L63-R68): Modified `build_qt` to use `compiler.extend()` for adding arguments and switched subprocess calls to pass a list for better handling of command-line arguments.
* [`tk_toolchain/cmd_line_tools/tk_build_qt_resources/__init__.py`](diffhunk://#diff-9967a30257c1f6bd43330bc7d3a12ef565823225c37e4a5df0af248d0ba66381L83-R94): Updated `build_ui` and `build_res` functions to construct `compiler` as a list instead of a formatted string, ensuring safer and more flexible argument handling. [[1]](diffhunk://#diff-9967a30257c1f6bd43330bc7d3a12ef565823225c37e4a5df0af248d0ba66381L83-R94) [[2]](diffhunk://#diff-9967a30257c1f6bd43330bc7d3a12ef565823225c37e4a5df0af248d0ba66381L94-R110)

### Environment variable updates:

* [`tk_toolchain/cmd_line_tools/tk_build_qt_resources/__init__.py`](diffhunk://#diff-9967a30257c1f6bd43330bc7d3a12ef565823225c37e4a5df0af248d0ba66381L164-R180): Changed the default value for the `--pyenv` argument to prioritize `PYENV_VIRTUAL_ENV` or `VIRTUAL_ENV` over `PYTHONPATH`, aligning with modern virtual environment practices.

### Refinement of PySide2 tool paths:

* [`tk_toolchain/cmd_line_tools/tk_build_qt_resources/__init__.py`](diffhunk://#diff-9967a30257c1f6bd43330bc7d3a12ef565823225c37e4a5df0af248d0ba66381L176-R193): Updated the paths for `pyside2-uic` and `pyside2-rcc` to explicitly include the `bin` directory, ensuring compatibility with virtual environments.